### PR TITLE
feat: implement structs around box score generator for simulation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,7 @@ version = "1.0.0"
 dependencies = [
  "rand",
  "rand_distr",
+ "serde",
 ]
 
 [[package]]
@@ -126,6 +127,26 @@ checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
  "rand",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.217"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.217"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ categories = ["football","simulation"]
 [dependencies]
 rand = "0.8.5"
 rand_distr = "0.4.3"
+serde = { version = "1.0.217", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -4,11 +4,9 @@
 
 ## Overview
 
-In its initial iteration, this crate provides utilities for simulating american football leagues at the box score level.  The `BoxScoreGenerator` struct which will generate an american football box score given the normalized skill differential between the home offense and the away defense, and vice versa, the away offense and the home defense.  It is based on the four regression models derived [in this repository](https://github.com/whatsacomputertho/fbdb-boxscore-eda).
+In its initial iteration, this crate provides utilities for simulating american football leagues at the box score level.  It is based on the four regression models derived [in this repository](https://github.com/whatsacomputertho/fbdb-boxscore-eda).
 
 ## Usage
-
-Below, usage is given for the `BoxScoreGenerator` 
 
 ### Adding via Cargo
 
@@ -17,31 +15,37 @@ To add the package to your project, run the following from your project director
 cargo add fbsim_core
 ```
 
-### Box score generator
+### Box score simulator
 
-One can instantiate the generator with normalized differentials defaulted to `0.5_f64` respectively using the `BoxScoreGenerator::new()` method.  It is recommended in this case to instantiate it as mutable so that the setters can be used to set the normalized differentials later.
+To simulate a game using the box score simulator, one might replicate the following example.  Note that `FootballTeam` and `BoxScore` both derive the serde `Serialize` and `Deserialize` traits and thus may be instantiated from JSON.
 
 ```rust
-// Instantiate the BoxScoreGenerator with default normalized differentials
-let mut my_box_score_gen = BoxScoreGenerator::new();
+use rand::Rng;
+use fbsim_core::boxscore::BoxScore;
+use fbsim_core::sim::BoxScoreSimulator;
+use fbsim_core::team::FootballTeam;
 
-// Then set the normalized differentials later
-my_box_score_gen.set_home_off_away_def_norm_diff(0.75_f64).unwrap();
-my_box_score_gen.set_away_off_home_def_norm_diff(0.25_f64).unwrap();
-```
+// Instantiate the simulator
+let my_box_score_sim = BoxScoreSimulator::new();
 
-Or one can instantiate the generator with values explicitly given at instantiation time.
-```rust
-let my_box_score_gen = BoxScoreGenerator::from_properties(
-    0.75_f64,
-    0.25_f64
+// Instantiate the home and away team
+let home_team = FootballTeam::from_properties(
+    "Home Team",
+    75,
+    67
 );
-```
+let away_team = FootballTeam::from_properties(
+    "Away Team",
+    88,
+    95
+);
 
-Once the generator is instantiated, one can simply call the `gen()` method on it, passing a mutable [`rand::Rng`](https://docs.rs/rand/latest/rand/trait.Rng.html) instance as an argument.
-
-```rust
+// Instantiate an RNG and simulate
 let mut rng = rand::thread_rng();
-let my_box_score_gen = BoxScoreGenerator::new();
-let (home_score, away_score): (i32, i32) = my_box_score_gen.gen(&mut rng);
+let my_box_score = my_box_score_sim.sim(
+    &home_team,
+    &away_team,
+    &mut rng
+);
+println!("{}", my_box_score);
 ```

--- a/src/boxscore.rs
+++ b/src/boxscore.rs
@@ -1,217 +1,100 @@
-use rand::Rng;
-use rand_distr::{Normal, Distribution};
+use serde::{Serialize, Deserialize};
+use crate::team::{DEFAULT_TEAM_NAME};
 
-// Home score generator model weights
-const H_MEAN_INTERCEPT: f64 = 23.14578315_f64;
-const H_MEAN_COEF: f64 = 10.9716991_f64;
-const H_STD_INTERCEPT: f64 = 7.64006156_f64;
-const H_STD_COEF_1: f64 = 5.72612946_f64;
-const H_STD_COEF_2: f64 = -4.29283414_f64;
-
-// Away score generator model weights
-const A_MEAN_INTERCEPT: f64 = 22.14952374_f64;
-const A_MEAN_COEF: f64 = 8.92113289_f64;
-const A_STD_INTERCEPT: f64 = 6.47638621_f64;
-const A_STD_COEF_1: f64 = 8.00861267_f64;
-const A_STD_COEF_2: f64 = -5.589282_f64;
-
-/// # `BoxScoreGenerator` struct
+/// # `BoxScore` struct
 ///
-/// A `BoxScoreGenerator` generates an american football box score
-/// given the normalized skill differential (in range [0, 1]) of the
-/// home offense and the away defense, and vice versa, the away
-/// offense and the home defense.
-#[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Default)]
-pub struct BoxScoreGenerator {
-    home_off_away_def_norm_diff: f64,
-    away_off_home_def_norm_diff: f64
+/// A `BoxScore` represents the result of a football game
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Default, Serialize, Deserialize)]
+pub struct BoxScore {
+    home_team: String,
+    home_score: i32,
+    away_team: String,
+    away_score: i32
 }
 
-impl BoxScoreGenerator {
-    /// Constructor for the `BoxScoreGenerator` struct in which each
-    /// skill differential is defaulted to 0.5_f64,
+impl BoxScore {
+    /// Constructor for the `BoxScore` struct in which each score
+    /// is defaulted to 0_i32, and each team name is defaulted to
+    /// the default team name.
     ///
     /// ### Example
     /// ```
-    /// use fbsim_core::boxscore::BoxScoreGenerator;
+    /// use fbsim_core::boxscore::BoxScore;
     ///
-    /// let my_box_score_gen = BoxScoreGenerator::new();
+    /// let my_score = BoxScore::new();
     /// ```
-    pub fn new() -> BoxScoreGenerator {
-        BoxScoreGenerator{
-            home_off_away_def_norm_diff: 0.5_f64,
-            away_off_home_def_norm_diff: 0.5_f64
+    pub fn new() -> BoxScore {
+        BoxScore{
+            home_team: String::from(DEFAULT_TEAM_NAME),
+            home_score: 0_i32,
+            away_team: String::from(DEFAULT_TEAM_NAME),
+            away_score: 0_i32
         }
     }
 
-    /// Constructor for the `BoxScoreGenerator` struct in which its
-    /// struct properties are given as arguments.  Here, the first
-    /// argument is the normalized differential between the home
-    /// offensive skill and the away defensive skill.  The second
-    /// argument is then the normalized skill differential between
-    /// the away offense and the home defense.
+    /// Constructor for the `BoxScore` struct in which each
+    /// property is given as an argument.
     ///
     /// ### Example
     /// ```
-    /// use fbsim_core::boxscore::BoxScoreGenerator;
+    /// use fbsim_core::boxscore::BoxScore;
     ///
-    /// let my_home_off_away_def_norm_diff = 0.75_f64;
-    /// let my_away_off_home_def_norm_diff = 0.33_f64;
-    /// let my_box_score_gen = BoxScoreGenerator::from_properties(
-    ///     my_home_off_away_def_norm_diff,
-    ///     my_away_off_home_def_norm_diff
+    /// let my_score = BoxScore::from_properties(
+    ///     "My Team A",
+    ///     24_i32,
+    ///     "My Team B",
+    ///     17_i32
     /// );
     /// ```
-    pub fn from_properties(ha_norm_diff: f64, ah_norm_diff: f64) -> Result<BoxScoreGenerator, String> {
-        // Ensure normalized differentials are in range [0, 1]
-        if !(ha_norm_diff >= 0.0_f64 && ha_norm_diff <= 1.0_f64) {
+    pub fn from_properties(home_team: &str, home_score: i32, away_team: &str, away_score: i32) -> Result<BoxScore, String> {
+        // Ensure home and away scores are in range [0, max)
+        if !home_score >= 0_i32 {
             return Err(
                 format!(
-                    "Home offense / away defense noralized skill differential not in range [0, 1]: {}",
-                    ha_norm_diff
+                    "Home score not in range [0, max): {}",
+                    home_score
                 )
             )
         }
-        if !(ah_norm_diff >= 0.0_f64 && ah_norm_diff <= 1.0_f64) {
+        if !away_score >= 0_i32 {
             return Err(
                 format!(
-                    "Away offense / home defense noralized skill differential not in range [0, 1]: {}",
-                    ah_norm_diff
+                    "Away score not in range [0, max): {}",
+                    away_score
                 )
             )
         }
-
-        // If so then return the result wrapping the instantiated struct
         Ok(
-            BoxScoreGenerator{
-                home_off_away_def_norm_diff: ha_norm_diff,
-                away_off_home_def_norm_diff: ah_norm_diff
+            BoxScore{
+                home_team: String::from(home_team),
+                home_score: home_score,
+                away_team: String::from(away_team),
+                away_score: away_score
             }
         )
     }
+}
 
-    /// Set the home offense to away defense normalized skill differential.
-    /// Returns a result describing whether the mutation succeeded.
+impl std::fmt::Display for BoxScore {
+    /// Format a `BoxScore` as a string.
     ///
     /// ### Example
-    /// ```
-    /// use fbsim_core::boxscore::BoxScoreGenerator;
-    /// 
-    /// let mut my_box_score_gen = BoxScoreGenerator::new();
-    /// my_box_score_gen.set_home_off_away_def_norm_diff(0.75_f64).unwrap();
-    /// ```
-    pub fn set_home_off_away_def_norm_diff(&mut self, ha_norm_diff: f64) -> Result<(), String> {
-        // Ensure normalized differential is in range [0, 1]
-        if !(ha_norm_diff >= 0.0_f64 && ha_norm_diff <= 1.0_f64) {
-            return Err(
-                format!(
-                    "Home offense / away defense noralized skill differential not in range [0, 1]: {}",
-                    ha_norm_diff
-                )
-            )
-        }
-
-        // If so, set the normalized differential
-        self.home_off_away_def_norm_diff = ha_norm_diff;
-        Ok(())
-    }
-
-    /// Set the away offense to home defense normalized skill differential.
-    /// Returns a result describing whether the mutation succeeded.
     ///
-    /// ### Example
     /// ```
-    /// use fbsim_core::boxscore::BoxScoreGenerator;
-    /// 
-    /// let mut my_box_score_gen = BoxScoreGenerator::new();
-    /// my_box_score_gen.set_away_off_home_def_norm_diff(0.25_f64).unwrap();
-    /// ```
-    pub fn set_away_off_home_def_norm_diff(&mut self, ah_norm_diff: f64) -> Result<(), String> {
-        // Ensure normalized differential is in range [0, 1]
-        if !(ah_norm_diff >= 0.0_f64 && ah_norm_diff <= 1.0_f64) {
-            return Err(
-                format!(
-                    "Away offense / home defense noralized skill differential not in range [0, 1]: {}",
-                    ah_norm_diff
-                )
-            )
-        }
-
-        // If so, set the normalized differential
-        self.away_off_home_def_norm_diff = ah_norm_diff;
-        Ok(())
-    }
-
-    /// Gets the mean score parameter for the away generation
-    fn get_mean_score(&self, home: bool) -> f64 {
-        if home {
-            H_MEAN_INTERCEPT + (H_MEAN_COEF * self.home_off_away_def_norm_diff)
-        } else {
-            A_MEAN_INTERCEPT + (A_MEAN_COEF * self.away_off_home_def_norm_diff)
-        }
-    }
-
-    /// Gets the score standard deviation parameter for the score
-    /// generation
-    fn get_std_score(&self, home: bool) -> f64 {
-        if home {
-            H_STD_INTERCEPT + (H_STD_COEF_1 * self.home_off_away_def_norm_diff) + (H_STD_COEF_2 * self.home_off_away_def_norm_diff.powi(2))
-        } else {
-            A_STD_INTERCEPT + (A_STD_COEF_1 * self.away_off_home_def_norm_diff) + (A_STD_COEF_2 * self.away_off_home_def_norm_diff.powi(2))
-        }
-    }
-
-    /// Gets the normal distribution parameters for the score generation
-    fn get_normal_params(&self, home: bool) -> (f64, f64) {
-        (self.get_mean_score(home), self.get_std_score(home))
-    }
-
-    /// Generates the away score only
-    fn gen_away_score(&self, rng: &mut impl Rng) -> i32 {
-        // Create and sample a normal distribution for the score
-        let (mean, std) = self.get_normal_params(false);
-        let away_dist = Normal::new(mean, std).unwrap();
-        let away_score_float = away_dist.sample(rng);
-
-        // Round to nearest integer and return
-        let away_score = if away_score_float < 0_f64 {
-            0_i32
-        } else {
-            away_score_float.round() as i32
-        };
-        return away_score
-    }
-
-    /// Generates the home score only
-    fn gen_home_score(&self, rng: &mut impl Rng) -> i32 {
-        // Create and sample a normal distribution for the score
-        let (mean, std) = self.get_normal_params(true);
-        let home_dist = Normal::new(mean, std).unwrap();
-        let home_score_float = home_dist.sample(rng);
-
-        // Round to nearest integer, ensure positive and return
-        let home_score = if home_score_float < 0_f64 {
-            0_i32
-        } else {
-            home_score_float.round() as i32
-        };
-        return home_score
-    }
-
-    /// Generates the home and away scores, returns as a 2-tuple
-    /// in which the first value is the home score, and the second
-    /// value is the away score
+    /// use fbsim_core::boxscore::BoxScore;
     ///
-    /// ### Example
+    /// let my_box_score = BoxScore::new();
+    /// println!("{}", my_box_score);
     /// ```
-    /// use fbsim_core::boxscore::BoxScoreGenerator;
-    /// 
-    /// let mut rng = rand::thread_rng();
-    /// let my_box_score_gen = BoxScoreGenerator::new();
-    /// let (home_score, away_score): (i32, i32) = my_box_score_gen.gen(&mut rng);
-    /// ```
-    pub fn gen(&self, rng: &mut impl Rng) -> (i32, i32) {
-        (self.gen_home_score(rng), self.gen_away_score(rng))
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let score_str = format!(
+            "{} {} - {} {}",
+            self.home_team,
+            self.home_score,
+            self.away_team,
+            self.away_score
+        );
+        f.write_str(&score_str)
     }
 }
 
@@ -220,133 +103,40 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_box_score_gen_from_properties() {
-        // Test H/A diff OOB low
-        let result_a = BoxScoreGenerator::from_properties(
-            -1_f64,
-            0.5_f64
-        );
-        let expected_a: Result<BoxScoreGenerator, String> = Err(
-            String::from("Home offense / away defense noralized skill differential not in range [0, 1]: -1")
+    fn test_box_score_from_properties() {
+        // Test home score OOB
+        let result_a = BoxScore::from_properties("Test Team A", -3, "Test Team B", 24);
+        let expected_a: Result<BoxScore, String> = Err(
+            String::from("Home score not in range [0, max): -3")
         );
         assert_eq!(
             result_a,
             expected_a
         );
 
-        // Test H/A diff OOB high
-        let result_b = BoxScoreGenerator::from_properties(
-            13.37_f64,
-            0.5_f64
-        );
-        let expected_b: Result<BoxScoreGenerator, String> = Err(
-            String::from("Home offense / away defense noralized skill differential not in range [0, 1]: 13.37")
+        // Test away score OOB
+        let result_b = BoxScore::from_properties("Test Team A", 17, "Test Team B", -17);
+        let expected_b: Result<BoxScore, String> = Err(
+            String::from("Away score not in range [0, max): -17")
         );
         assert_eq!(
             result_b,
             expected_b
         );
 
-        // Test A/H diff OOB low
-        let result_c = BoxScoreGenerator::from_properties(
-            0.5_f64,
-            -3.3_f64
-        );
-        let expected_c: Result<BoxScoreGenerator, String> = Err(
-            String::from("Away offense / home defense noralized skill differential not in range [0, 1]: -3.3")
+        // Test both scores in range
+        let result_c = BoxScore::from_properties("Test Team A", 17, "Test Team B", 24);
+        let expected_c: Result<BoxScore, String> = Ok(
+            BoxScore{
+                home_team: String::from("Test Team A"),
+                home_score: 17,
+                away_team: String::from("Test Team B"),
+                away_score: 24
+            }
         );
         assert_eq!(
             result_c,
             expected_c
         );
-
-        // Test A/H diff OOB high
-        let result_d = BoxScoreGenerator::from_properties(
-            0.5_f64,
-            4.4_f64
-        );
-        let expected_d: Result<BoxScoreGenerator, String> = Err(
-            String::from("Away offense / home defense noralized skill differential not in range [0, 1]: 4.4")
-        );
-        assert_eq!(
-            result_d,
-            expected_d
-        );
-
-        // Test both diffs in valid range
-        let result_e = BoxScoreGenerator::from_properties(
-            0.0001_f64,
-            0.9999_f64
-        );
-        let expected_e: Result<BoxScoreGenerator, String> = Ok(
-            BoxScoreGenerator{
-                home_off_away_def_norm_diff: 0.0001_f64,
-                away_off_home_def_norm_diff: 0.9999_f64
-            }
-        );
-        assert_eq!(
-            result_e,
-            expected_e
-        );
-    }
-
-    #[test]
-    fn test_box_score_gen_setters() {
-        // Initialize a BoxScoreGenerator
-        let mut box_score_gen = BoxScoreGenerator::new();
-
-        // Test H/A diff OOB and in range
-        let result_a = box_score_gen.set_home_off_away_def_norm_diff(-6.9_f64);
-        let expected_a: Result<(), String> = Err(
-            String::from("Home offense / away defense noralized skill differential not in range [0, 1]: -6.9")
-        );
-        assert_eq!(result_a, expected_a);
-        let result_b = box_score_gen.set_home_off_away_def_norm_diff(7.7123456_f64);
-        let expected_b: Result<(), String> = Err(
-            String::from("Home offense / away defense noralized skill differential not in range [0, 1]: 7.7123456")
-        );
-        assert_eq!(result_b, expected_b);
-        let result_c = box_score_gen.set_home_off_away_def_norm_diff(0.25_f64);
-        let expected_c: Result<(), String> = Ok(());
-        assert_eq!(result_c, expected_c);
-
-        // Test A/H diff OOB and in range
-        let result_d = box_score_gen.set_away_off_home_def_norm_diff(-5.567_f64);
-        let expected_d: Result<(), String> = Err(
-            String::from("Away offense / home defense noralized skill differential not in range [0, 1]: -5.567")
-        );
-        assert_eq!(result_d, expected_d);
-        let result_e = box_score_gen.set_away_off_home_def_norm_diff(400.0001_f64);
-        let expected_e: Result<(), String> = Err(
-            String::from("Away offense / home defense noralized skill differential not in range [0, 1]: 400.0001")
-        );
-        assert_eq!(result_e, expected_e);
-        let result_f = box_score_gen.set_away_off_home_def_norm_diff(0.25_f64);
-        let expected_f: Result<(), String> = Ok(());
-        assert_eq!(result_f, expected_f);
-    }
-
-    #[test]
-    fn test_box_score_gen() {
-        // Initialize a box score generator and an rng
-        let mut rng = rand::thread_rng();
-        let box_score_gen = BoxScoreGenerator::new();
-
-        // Generate and validate a few box scores
-        let (home_a, away_a) = box_score_gen.gen(&mut rng);
-        let (home_b, away_b) = box_score_gen.gen(&mut rng);
-        let (home_c, away_c) = box_score_gen.gen(&mut rng);
-        let (home_d, away_d) = box_score_gen.gen(&mut rng);
-        let (home_e, away_e) = box_score_gen.gen(&mut rng);
-        assert!(home_a > 0);
-        assert!(home_b > 0);
-        assert!(home_c > 0);
-        assert!(home_d > 0);
-        assert!(home_e > 0);
-        assert!(away_a > 0);
-        assert!(away_b > 0);
-        assert!(away_c > 0);
-        assert!(away_d > 0);
-        assert!(away_e > 0);
     }
 }

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -1,0 +1,352 @@
+use rand::Rng;
+use rand_distr::{Normal, Distribution};
+
+// Home score generator model weights
+const H_MEAN_INTERCEPT: f64 = 23.14578315_f64;
+const H_MEAN_COEF: f64 = 10.9716991_f64;
+const H_STD_INTERCEPT: f64 = 7.64006156_f64;
+const H_STD_COEF_1: f64 = 5.72612946_f64;
+const H_STD_COEF_2: f64 = -4.29283414_f64;
+
+// Away score generator model weights
+const A_MEAN_INTERCEPT: f64 = 22.14952374_f64;
+const A_MEAN_COEF: f64 = 8.92113289_f64;
+const A_STD_INTERCEPT: f64 = 6.47638621_f64;
+const A_STD_COEF_1: f64 = 8.00861267_f64;
+const A_STD_COEF_2: f64 = -5.589282_f64;
+
+/// # `BoxScoreGenerator` struct
+///
+/// A `BoxScoreGenerator` generates an american football box score
+/// given the normalized skill differential (in range [0, 1]) of the
+/// home offense and the away defense, and vice versa, the away
+/// offense and the home defense.
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Default)]
+pub struct BoxScoreGenerator {
+    home_off_away_def_norm_diff: f64,
+    away_off_home_def_norm_diff: f64
+}
+
+impl BoxScoreGenerator {
+    /// Constructor for the `BoxScoreGenerator` struct in which each
+    /// skill differential is defaulted to 0.5_f64
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::gen::BoxScoreGenerator;
+    ///
+    /// let my_box_score_gen = BoxScoreGenerator::new();
+    /// ```
+    pub fn new() -> BoxScoreGenerator {
+        BoxScoreGenerator{
+            home_off_away_def_norm_diff: 0.5_f64,
+            away_off_home_def_norm_diff: 0.5_f64
+        }
+    }
+
+    /// Constructor for the `BoxScoreGenerator` struct in which its
+    /// struct properties are given as arguments.  Here, the first
+    /// argument is the normalized differential between the home
+    /// offensive skill and the away defensive skill.  The second
+    /// argument is then the normalized skill differential between
+    /// the away offense and the home defense.
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::gen::BoxScoreGenerator;
+    ///
+    /// let my_home_off_away_def_norm_diff = 0.75_f64;
+    /// let my_away_off_home_def_norm_diff = 0.33_f64;
+    /// let my_box_score_gen = BoxScoreGenerator::from_properties(
+    ///     my_home_off_away_def_norm_diff,
+    ///     my_away_off_home_def_norm_diff
+    /// );
+    /// ```
+    pub fn from_properties(ha_norm_diff: f64, ah_norm_diff: f64) -> Result<BoxScoreGenerator, String> {
+        // Ensure normalized differentials are in range [0, 1]
+        if !(ha_norm_diff >= 0.0_f64 && ha_norm_diff <= 1.0_f64) {
+            return Err(
+                format!(
+                    "Home offense / away defense noralized skill differential not in range [0, 1]: {}",
+                    ha_norm_diff
+                )
+            )
+        }
+        if !(ah_norm_diff >= 0.0_f64 && ah_norm_diff <= 1.0_f64) {
+            return Err(
+                format!(
+                    "Away offense / home defense noralized skill differential not in range [0, 1]: {}",
+                    ah_norm_diff
+                )
+            )
+        }
+
+        // If so then return the result wrapping the instantiated struct
+        Ok(
+            BoxScoreGenerator{
+                home_off_away_def_norm_diff: ha_norm_diff,
+                away_off_home_def_norm_diff: ah_norm_diff
+            }
+        )
+    }
+
+    /// Set the home offense to away defense normalized skill differential.
+    /// Returns a result describing whether the mutation succeeded.
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::gen::BoxScoreGenerator;
+    /// 
+    /// let mut my_box_score_gen = BoxScoreGenerator::new();
+    /// my_box_score_gen.set_home_off_away_def_norm_diff(0.75_f64).unwrap();
+    /// ```
+    pub fn set_home_off_away_def_norm_diff(&mut self, ha_norm_diff: f64) -> Result<(), String> {
+        // Ensure normalized differential is in range [0, 1]
+        if !(ha_norm_diff >= 0.0_f64 && ha_norm_diff <= 1.0_f64) {
+            return Err(
+                format!(
+                    "Home offense / away defense noralized skill differential not in range [0, 1]: {}",
+                    ha_norm_diff
+                )
+            )
+        }
+
+        // If so, set the normalized differential
+        self.home_off_away_def_norm_diff = ha_norm_diff;
+        Ok(())
+    }
+
+    /// Set the away offense to home defense normalized skill differential.
+    /// Returns a result describing whether the mutation succeeded.
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::gen::BoxScoreGenerator;
+    /// 
+    /// let mut my_box_score_gen = BoxScoreGenerator::new();
+    /// my_box_score_gen.set_away_off_home_def_norm_diff(0.25_f64).unwrap();
+    /// ```
+    pub fn set_away_off_home_def_norm_diff(&mut self, ah_norm_diff: f64) -> Result<(), String> {
+        // Ensure normalized differential is in range [0, 1]
+        if !(ah_norm_diff >= 0.0_f64 && ah_norm_diff <= 1.0_f64) {
+            return Err(
+                format!(
+                    "Away offense / home defense noralized skill differential not in range [0, 1]: {}",
+                    ah_norm_diff
+                )
+            )
+        }
+
+        // If so, set the normalized differential
+        self.away_off_home_def_norm_diff = ah_norm_diff;
+        Ok(())
+    }
+
+    /// Gets the mean score parameter for the away generation
+    fn get_mean_score(&self, home: bool) -> f64 {
+        if home {
+            H_MEAN_INTERCEPT + (H_MEAN_COEF * self.home_off_away_def_norm_diff)
+        } else {
+            A_MEAN_INTERCEPT + (A_MEAN_COEF * self.away_off_home_def_norm_diff)
+        }
+    }
+
+    /// Gets the score standard deviation parameter for the score
+    /// generation
+    fn get_std_score(&self, home: bool) -> f64 {
+        if home {
+            H_STD_INTERCEPT + (H_STD_COEF_1 * self.home_off_away_def_norm_diff) + (H_STD_COEF_2 * self.home_off_away_def_norm_diff.powi(2))
+        } else {
+            A_STD_INTERCEPT + (A_STD_COEF_1 * self.away_off_home_def_norm_diff) + (A_STD_COEF_2 * self.away_off_home_def_norm_diff.powi(2))
+        }
+    }
+
+    /// Gets the normal distribution parameters for the score generation
+    fn get_normal_params(&self, home: bool) -> (f64, f64) {
+        (self.get_mean_score(home), self.get_std_score(home))
+    }
+
+    /// Generates the away score only
+    fn gen_away_score(&self, rng: &mut impl Rng) -> i32 {
+        // Create and sample a normal distribution for the score
+        let (mean, std) = self.get_normal_params(false);
+        let away_dist = Normal::new(mean, std).unwrap();
+        let away_score_float = away_dist.sample(rng);
+
+        // Round to nearest integer and return
+        let away_score = if away_score_float < 0_f64 {
+            0_i32
+        } else {
+            away_score_float.round() as i32
+        };
+        return away_score
+    }
+
+    /// Generates the home score only
+    fn gen_home_score(&self, rng: &mut impl Rng) -> i32 {
+        // Create and sample a normal distribution for the score
+        let (mean, std) = self.get_normal_params(true);
+        let home_dist = Normal::new(mean, std).unwrap();
+        let home_score_float = home_dist.sample(rng);
+
+        // Round to nearest integer, ensure positive and return
+        let home_score = if home_score_float < 0_f64 {
+            0_i32
+        } else {
+            home_score_float.round() as i32
+        };
+        return home_score
+    }
+
+    /// Generates the home and away scores, returns as a 2-tuple
+    /// in which the first value is the home score, and the second
+    /// value is the away score
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::gen::BoxScoreGenerator;
+    /// 
+    /// let mut rng = rand::thread_rng();
+    /// let my_box_score_gen = BoxScoreGenerator::new();
+    /// let (home_score, away_score): (i32, i32) = my_box_score_gen.gen(&mut rng);
+    /// ```
+    pub fn gen(&self, rng: &mut impl Rng) -> (i32, i32) {
+        (self.gen_home_score(rng), self.gen_away_score(rng))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_box_score_gen_from_properties() {
+        // Test H/A diff OOB low
+        let result_a = BoxScoreGenerator::from_properties(
+            -1_f64,
+            0.5_f64
+        );
+        let expected_a: Result<BoxScoreGenerator, String> = Err(
+            String::from("Home offense / away defense noralized skill differential not in range [0, 1]: -1")
+        );
+        assert_eq!(
+            result_a,
+            expected_a
+        );
+
+        // Test H/A diff OOB high
+        let result_b = BoxScoreGenerator::from_properties(
+            13.37_f64,
+            0.5_f64
+        );
+        let expected_b: Result<BoxScoreGenerator, String> = Err(
+            String::from("Home offense / away defense noralized skill differential not in range [0, 1]: 13.37")
+        );
+        assert_eq!(
+            result_b,
+            expected_b
+        );
+
+        // Test A/H diff OOB low
+        let result_c = BoxScoreGenerator::from_properties(
+            0.5_f64,
+            -3.3_f64
+        );
+        let expected_c: Result<BoxScoreGenerator, String> = Err(
+            String::from("Away offense / home defense noralized skill differential not in range [0, 1]: -3.3")
+        );
+        assert_eq!(
+            result_c,
+            expected_c
+        );
+
+        // Test A/H diff OOB high
+        let result_d = BoxScoreGenerator::from_properties(
+            0.5_f64,
+            4.4_f64
+        );
+        let expected_d: Result<BoxScoreGenerator, String> = Err(
+            String::from("Away offense / home defense noralized skill differential not in range [0, 1]: 4.4")
+        );
+        assert_eq!(
+            result_d,
+            expected_d
+        );
+
+        // Test both diffs in valid range
+        let result_e = BoxScoreGenerator::from_properties(
+            0.0001_f64,
+            0.9999_f64
+        );
+        let expected_e: Result<BoxScoreGenerator, String> = Ok(
+            BoxScoreGenerator{
+                home_off_away_def_norm_diff: 0.0001_f64,
+                away_off_home_def_norm_diff: 0.9999_f64
+            }
+        );
+        assert_eq!(
+            result_e,
+            expected_e
+        );
+    }
+
+    #[test]
+    fn test_box_score_gen_setters() {
+        // Initialize a BoxScoreGenerator
+        let mut box_score_gen = BoxScoreGenerator::new();
+
+        // Test H/A diff OOB and in range
+        let result_a = box_score_gen.set_home_off_away_def_norm_diff(-6.9_f64);
+        let expected_a: Result<(), String> = Err(
+            String::from("Home offense / away defense noralized skill differential not in range [0, 1]: -6.9")
+        );
+        assert_eq!(result_a, expected_a);
+        let result_b = box_score_gen.set_home_off_away_def_norm_diff(7.7123456_f64);
+        let expected_b: Result<(), String> = Err(
+            String::from("Home offense / away defense noralized skill differential not in range [0, 1]: 7.7123456")
+        );
+        assert_eq!(result_b, expected_b);
+        let result_c = box_score_gen.set_home_off_away_def_norm_diff(0.25_f64);
+        let expected_c: Result<(), String> = Ok(());
+        assert_eq!(result_c, expected_c);
+
+        // Test A/H diff OOB and in range
+        let result_d = box_score_gen.set_away_off_home_def_norm_diff(-5.567_f64);
+        let expected_d: Result<(), String> = Err(
+            String::from("Away offense / home defense noralized skill differential not in range [0, 1]: -5.567")
+        );
+        assert_eq!(result_d, expected_d);
+        let result_e = box_score_gen.set_away_off_home_def_norm_diff(400.0001_f64);
+        let expected_e: Result<(), String> = Err(
+            String::from("Away offense / home defense noralized skill differential not in range [0, 1]: 400.0001")
+        );
+        assert_eq!(result_e, expected_e);
+        let result_f = box_score_gen.set_away_off_home_def_norm_diff(0.25_f64);
+        let expected_f: Result<(), String> = Ok(());
+        assert_eq!(result_f, expected_f);
+    }
+
+    #[test]
+    fn test_box_score_gen() {
+        // Initialize a box score generator and an rng
+        let mut rng = rand::thread_rng();
+        let box_score_gen = BoxScoreGenerator::new();
+
+        // Generate and validate a few box scores
+        let (home_a, away_a) = box_score_gen.gen(&mut rng);
+        let (home_b, away_b) = box_score_gen.gen(&mut rng);
+        let (home_c, away_c) = box_score_gen.gen(&mut rng);
+        let (home_d, away_d) = box_score_gen.gen(&mut rng);
+        let (home_e, away_e) = box_score_gen.gen(&mut rng);
+        assert!(home_a >= 0);
+        assert!(home_b >= 0);
+        assert!(home_c >= 0);
+        assert!(home_d >= 0);
+        assert!(home_e >= 0);
+        assert!(away_a >= 0);
+        assert!(away_b >= 0);
+        assert!(away_c >= 0);
+        assert!(away_d >= 0);
+        assert!(away_e >= 0);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,4 @@
 pub mod boxscore;
+pub mod gen;
+pub mod sim;
+pub mod team;

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -1,0 +1,62 @@
+use crate::boxscore::BoxScore;
+use crate::gen::BoxScoreGenerator;
+use crate::team::FootballTeam;
+
+use rand::Rng;
+
+/// `BoxScoreSimulator` struct
+///
+/// The `BoxScoreSimulator` struct simulates a game by simply
+/// generating a box score result
+pub struct BoxScoreSimulator;
+
+impl BoxScoreSimulator {
+    /// Constructor for the `BoxScoreSimulator` struct
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::sim::BoxScoreSimulator;
+    ///
+    /// let my_sim = BoxScoreSimulator::new();
+    /// ```
+    pub fn new() -> BoxScoreSimulator {
+        BoxScoreSimulator{}
+    }
+
+    /// Simulates a game by generating a box score result
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::boxscore::BoxScore;
+    /// use fbsim_core::sim::BoxScoreSimulator;
+    /// use fbsim_core::team::FootballTeam;
+    ///
+    /// let home = FootballTeam::new();
+    /// let away = FootballTeam::new();
+    /// let sim = BoxScoreSimulator::new();
+    /// let mut rng = rand::thread_rng();
+    /// let score = sim.sim(&home, &away, &mut rng);
+    /// println!("{}", score);
+    /// ```
+    pub fn sim(&self, home_team: &FootballTeam, away_team: &FootballTeam, rng: &mut impl Rng) -> BoxScore {
+        // Calculate the normalized skill differentials
+        let ha_norm_diff: f64 = ((home_team.offense_overall() - away_team.defense_overall() + 100) / 200) as f64;
+        let ah_norm_diff: f64 = ((away_team.offense_overall() - home_team.defense_overall() + 100) / 200) as f64;
+
+        // Generate the box score
+        let box_score_gen: BoxScoreGenerator = BoxScoreGenerator::from_properties(
+            ha_norm_diff,
+            ah_norm_diff
+        ).unwrap();
+        let (home_score, away_score): (i32, i32) = box_score_gen.gen(rng);
+
+        // Instantiate as a BoxScore and return
+        let box_score: BoxScore = BoxScore::from_properties(
+            home_team.name(),
+            home_score,
+            away_team.name(),
+            away_score
+        ).unwrap();
+        box_score
+    }
+}

--- a/src/team.rs
+++ b/src/team.rs
@@ -1,0 +1,206 @@
+use serde::{Serialize, Deserialize};
+
+pub const DEFAULT_TEAM_NAME: &str = "Null Island Defaults";
+
+/// # `FootballTeam` struct
+///
+/// A `FootballTeam` represents a football team
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Default, Serialize, Deserialize)]
+pub struct FootballTeam {
+    name: String,
+    offense_overall: i32,
+    defense_overall: i32
+}
+
+impl FootballTeam {
+    /// Constructor for the `FootballTeam` struct in which each
+    /// overall is defaulted to 50_i32, and the name is defaulted
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::FootballTeam;
+    ///
+    /// let my_team = FootballTeam::new();
+    /// ```
+    pub fn new() -> FootballTeam {
+        FootballTeam{
+            name: String::from(DEFAULT_TEAM_NAME),
+            offense_overall: 50_i32,
+            defense_overall: 50_i32
+        }
+    }
+
+    /// Constructor for the `FootballTeam` struct in which each
+    /// property is given as an argument.
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::FootballTeam;
+    ///
+    /// let my_team = FootballTeam::new();
+    /// ```
+    pub fn from_properties(name: &str, offense_overall: i32, defense_overall: i32) -> Result<FootballTeam, String> {
+        // Ensure offense and defense overall are in range [0, 100]
+        if !(offense_overall >= 0_i32 && offense_overall <= 100_i32) {
+            return Err(
+                format!(
+                    "Offense overall not in range [0, 100]: {}",
+                    offense_overall
+                )
+            )
+        }
+        if !(defense_overall >= 0_i32 && defense_overall <= 100_i32) {
+            return Err(
+                format!(
+                    "Defense overall not in range [0, 100]: {}",
+                    defense_overall
+                )
+            )
+        }
+        Ok(
+            FootballTeam{
+                name: String::from(name),
+                offense_overall: offense_overall,
+                defense_overall: defense_overall
+            }
+        )
+    }
+
+    /// Get the football team's name
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::FootballTeam;
+    ///
+    /// let my_team = FootballTeam::new();
+    /// let name = my_team.name();
+    /// ```
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Get the football team's name mutably
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::FootballTeam;
+    ///
+    /// let mut my_team = FootballTeam::new();
+    /// let mut name = my_team.name_mut();
+    /// ```
+    pub fn name_mut(&mut self) -> &mut String {
+        &mut self.name
+    }
+
+    /// Get the football team's offense overall
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::FootballTeam;
+    ///
+    /// let my_team = FootballTeam::new();
+    /// let offense = my_team.offense_overall();
+    /// ```
+    pub fn offense_overall(&self) -> &i32 {
+        &self.offense_overall
+    }
+
+    /// Get the football team's offense overall mutably
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::FootballTeam;
+    ///
+    /// let mut my_team = FootballTeam::new();
+    /// let mut offense = my_team.offense_overall_mut();
+    /// ```
+    pub fn offense_overall_mut(&mut self) -> &mut i32 {
+        &mut self.offense_overall
+    }
+
+    /// Get the football team's defense overall
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::FootballTeam;
+    ///
+    /// let my_team = FootballTeam::new();
+    /// let offense = my_team.defense_overall();
+    /// ```
+    pub fn defense_overall(&self) -> &i32 {
+        &self.defense_overall
+    }
+
+    /// Get the football team's defense overall mutably
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::FootballTeam;
+    ///
+    /// let mut my_team = FootballTeam::new();
+    /// let mut offense = my_team.defense_overall_mut();
+    /// ```
+    pub fn defense_overall_mut(&mut self) -> &mut i32 {
+        &mut self.defense_overall
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_football_team_from_properties() {
+        // Test offense overall OOB low
+        let result_a = FootballTeam::from_properties("Test Team", -20, 50);
+        let expected_a: Result<FootballTeam, String> = Err(
+            String::from("Offense overall not in range [0, 100]: -20")
+        );
+        assert_eq!(
+            result_a,
+            expected_a
+        );
+
+        // Test offense overall OOB high
+        let result_b = FootballTeam::from_properties("Test Team", 200, 50);
+        let expected_b: Result<FootballTeam, String> = Err(
+            String::from("Offense overall not in range [0, 100]: 200")
+        );
+        assert_eq!(
+            result_b,
+            expected_b
+        );
+
+        // Test defense overall OOB low
+        let result_c = FootballTeam::from_properties("Test Team", 50, -100);
+        let expected_c: Result<FootballTeam, String> = Err(
+            String::from("Defense overall not in range [0, 100]: -100")
+        );
+        assert_eq!(
+            result_c,
+            expected_c
+        );
+
+        // Test defense overall OOB low
+        let result_d = FootballTeam::from_properties("Test Team", 50, 150);
+        let expected_d: Result<FootballTeam, String> = Err(
+            String::from("Defense overall not in range [0, 100]: 150")
+        );
+        assert_eq!(
+            result_d,
+            expected_d
+        );
+
+        // Test both values in range
+        let result_e = FootballTeam::from_properties("Test Team", 50, 50);
+        let expected_e: Result<FootballTeam, String> = Ok(FootballTeam{
+            name: String::from("Test Team"),
+            offense_overall: 50,
+            defense_overall: 50
+        });
+        assert_eq!(
+            result_e,
+            expected_e
+        );
+    }
+}


### PR DESCRIPTION
In this PR, I implement the `FootballTeam`, `BoxScore`, and `BoxScoreSimulator` structs around the already written `BoxScoreGenerator` struct which allow for a simpler interface for simulating games.