### PR TITLE
fix: division error causing all teams to be evenly matched

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbsim-core"
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.3"
 dependencies = [
  "rand",
  "rand_distr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fbsim-core"
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.3"
 authors = ["whatsacomputertho"]
 edition = "2021"
 description = "A library for american football simulation"

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -40,8 +40,8 @@ impl BoxScoreSimulator {
     /// ```
     pub fn sim(&self, home_team: &FootballTeam, away_team: &FootballTeam, rng: &mut impl Rng) -> BoxScore {
         // Calculate the normalized skill differentials
-        let ha_norm_diff: f64 = ((home_team.offense_overall() - away_team.defense_overall() + 100) / 200) as f64;
-        let ah_norm_diff: f64 = ((away_team.offense_overall() - home_team.defense_overall() + 100) / 200) as f64;
+        let ha_norm_diff: f64 = (home_team.offense_overall() - away_team.defense_overall() + 100) as f64 / 200_f64;
+        let ah_norm_diff: f64 = (away_team.offense_overall() - home_team.defense_overall() + 100) as f64 / 200_f64;
 
         // Generate the box score
         let box_score_gen: BoxScoreGenerator = BoxScoreGenerator::from_properties(


### PR DESCRIPTION
In this PR, I fix a division error which was causing all teams to be evenly matched.  We were doing integer division which would always round back to 0, then converting to an f64.