### PR TITLE
feat: filter generated scores by score frequency distribution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +288,7 @@ dependencies = [
  "rand_distr",
  "rocket_okapi",
  "serde",
+ "statrs",
 ]
 
 [[package]]
@@ -610,6 +620,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9380b911e3e96d10c1f415da0876389aaf1b56759054eeb0de7df940c456ba1a"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +681,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "nalgebra"
+version = "0.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26aecdf64b707efd1310e3544d709c5c0ac61c13756046aaaba41be5c4f66a3b"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "rand",
+ "rand_distr",
+ "simba",
+ "typenum",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,10 +708,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -751,6 +827,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pear"
@@ -878,6 +960,12 @@ dependencies = [
  "num-traits",
  "rand",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "redox_syscall"
@@ -1094,6 +1182,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "schemars"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,6 +1304,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "simba"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a386a501cd104797982c15ae17aafe8b9261315b5d07e3ec803f2ea26be0fa"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,6 +1363,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b8c4a4445d81357df8b1a650d0d0d6fbbbfe99d064aa5e02f3e4022061476d8"
 dependencies = [
  "loom",
+]
+
+[[package]]
+name = "statrs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+dependencies = [
+ "approx",
+ "nalgebra",
+ "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -1497,6 +1619,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
 name = "ubyte"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1553,6 +1681,16 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wide"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rand = "0.8.5"
 rand_distr = "0.4.3"
 rocket_okapi = { version = "0.9.0", features = ["swagger"], optional = true }
 serde = { version = "1.0.217", features = ["derive"] }
+statrs = "0.18.0"
 
 [features]
 rocket_okapi = ["dep:rocket_okapi"]

--- a/src/freq.rs
+++ b/src/freq.rs
@@ -1,0 +1,104 @@
+use std::collections::BTreeMap;
+
+pub struct ScoreFrequencyLookup {
+    freq_lookup: BTreeMap<i32, i32>,
+}
+
+impl ScoreFrequencyLookup {
+    /// Constructor for the ScoreFrequencyLookup struct
+    pub fn new() -> ScoreFrequencyLookup {
+        ScoreFrequencyLookup{
+            freq_lookup: BTreeMap::new()
+        }
+    }
+
+    /// Insert a score into the lookup table
+    pub fn insert(&mut self, score: i32, freq: i32) {
+        self.freq_lookup.insert(
+            score, freq
+        );
+    }
+
+    /// Populate the lookup table
+    pub fn create(&mut self) {
+        self.insert(0, 443);
+        self.insert(1, 0);
+        self.insert(2, 7);
+        self.insert(3, 547);
+        self.insert(4, 1);
+        self.insert(5, 14);
+        self.insert(6, 431);
+        self.insert(7, 850);
+        self.insert(8, 220);
+        self.insert(9, 312);
+        self.insert(10, 1271);
+        self.insert(11, 50);
+        self.insert(12, 204);
+        self.insert(13, 1059);
+        self.insert(14, 1084);
+        self.insert(15, 171);
+        self.insert(16, 758);
+        self.insert(17, 1617);
+        self.insert(18, 105);
+        self.insert(19, 438);
+        self.insert(20, 1427);
+        self.insert(21, 949);
+        self.insert(22, 255);
+        self.insert(23, 865);
+        self.insert(24, 1354);
+        self.insert(25, 163);
+        self.insert(26, 427);
+        self.insert(27, 1115);
+        self.insert(28, 687);
+        self.insert(29, 188);
+        self.insert(30, 579);
+        self.insert(31, 899);
+        self.insert(32, 99);
+        self.insert(33, 241);
+        self.insert(34, 621);
+        self.insert(35, 305);
+        self.insert(36, 105);
+        self.insert(37, 289);
+        self.insert(38, 406);
+        self.insert(39, 42);
+        self.insert(40, 103);
+        self.insert(41, 225);
+        self.insert(42, 154);
+        self.insert(43, 47);
+        self.insert(44, 95);
+        self.insert(45, 140);
+        self.insert(46, 13);
+        self.insert(47, 26);
+        self.insert(48, 63);
+        self.insert(49, 44);
+        self.insert(50, 10);
+        self.insert(51, 30);
+        self.insert(52, 35);
+        self.insert(53, 2);
+        self.insert(54, 8);
+        self.insert(55, 16);
+        self.insert(56, 12);
+        self.insert(57, 2);
+        self.insert(58, 4);
+        self.insert(59, 7);
+        self.insert(60, 1);
+        self.insert(61, 1);
+        self.insert(62, 5);
+    }
+
+    /// Get the frequency of a score
+    pub fn frequency(&self, score: i32) -> Result<i32, String> {
+        if score < 0 {
+            return Err(
+                format!(
+                    "Score must be greater than 0: {}",
+                    score
+                )
+            )
+        }
+        match self.freq_lookup.get(&score) {
+            Some(freq) => return Ok(*freq),
+            None       => return Ok(1_i32),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod boxscore;
+pub mod freq;
 pub mod sim;
 pub mod team;


### PR DESCRIPTION
In this PR, I add a score frequency distribution lookup table, and use it to filter the generated scores by their frequency so that scores are more realistic.