### PR TITLE
refac: migrate football matchup struct into core lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbsim-core"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 dependencies = [
  "rand",
  "rand_distr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fbsim-core"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 authors = ["whatsacomputertho"]
 edition = "2021"
 description = "A library for american football simulation"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod boxscore;
 pub mod freq;
+pub mod matchup;
 pub mod sim;
 pub mod team;

--- a/src/matchup.rs
+++ b/src/matchup.rs
@@ -1,0 +1,29 @@
+#[cfg(feature = "rocket_okapi")]
+use rocket_okapi::okapi::schemars;
+#[cfg(feature = "rocket_okapi")]
+use rocket_okapi::okapi::schemars::JsonSchema;
+use serde::{Serialize, Deserialize};
+
+use crate::team::FootballTeam;
+
+/// # `FootballMatchup` struct
+///
+/// A FootballMatchup represents a matchup between a home and away team
+#[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Default, Deserialize, Serialize)]
+pub struct FootballMatchup {
+    home: FootballTeam,
+    away: FootballTeam
+}
+
+impl FootballMatchup {
+    /// Returns the home team in the matchup
+    pub fn home_team(&self) -> &FootballTeam {
+        &self.home
+    }
+
+    /// Returns the away team in the matchup
+    pub fn away_team(&self) -> &FootballTeam {
+        &self.away
+    }
+}


### PR DESCRIPTION
In this PR, I add the `FootballMatchup` struct from fbsim-api into fbsim-core.

For reference, see:
- https://github.com/whatsacomputertho/fbsim-api/issues/4