### PR TITLE
feat: re-sim ties to achieve observed tie probability per skill diff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fbsim-core"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 authors = ["whatsacomputertho"]
 edition = "2021"
 description = "A library for american football simulation"


### PR DESCRIPTION
In this PR, I implement the tie-resim capabilities specified in this issue:
- https://github.com/whatsacomputertho/fbsim-core/issues/15