### PR TITLE
fix: use home-away skill diff for ties

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbsim-core"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.7"
 dependencies = [
  "rand",
  "rand_distr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fbsim-core"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 authors = ["whatsacomputertho"]
 edition = "2021"
 description = "A library for american football simulation"

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -213,15 +213,10 @@ impl BoxScoreSimulator {
             return Ok(box_score)
         }
 
-        // If a tie is achieved after filtering, re-sim based on the skill
-        // differentials and their associated tie probability.  Start by
-        // calculating the average of the two skill differentials
-        let avg_norm_diff: f64 = (ha_norm_diff + ah_norm_diff) / 2_f64;
-
-        // Get the probability of a tie for the average skill differential.
+        // Get the probability of a tie for the home/away skill differential.
         // Use it to get the required probability of a re-sim to achieve the
         // observed tie probability in the end
-        let p_tie: f64 = self.get_p_tie(avg_norm_diff);
+        let p_tie: f64 = self.get_p_tie(ha_norm_diff);
         let p_res: f64 = self.get_p_resim(p_tie);
 
         // Sample a bernoulli distribution of p_res to determine whether


### PR DESCRIPTION
I noticed some weird behavior when using the average skill differential for getting the tie probability.  Now instead I think I should strictly use the home-away skill diff to decide the tie probability so that results are more predictable.

For reference, see:
- https://github.com/whatsacomputertho/fbsim-core/issues/15