### PR TITLE
fix: swap mean model intercept and coefficient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbsim-core"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 dependencies = [
  "rand",
  "rand_distr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fbsim-core"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 authors = ["whatsacomputertho"]
 edition = "2021"
 description = "A library for american football simulation"

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -7,15 +7,15 @@ use crate::team::FootballTeam;
 use crate::freq::ScoreFrequencyLookup;
 
 // Home score simulator model weights
-const H_MEAN_INTERCEPT: f64 = 23.14578315_f64;
-const H_MEAN_COEF: f64 = 10.9716991_f64;
+const H_MEAN_COEF: f64 = 23.14578315_f64;
+const H_MEAN_INTERCEPT: f64 = 10.9716991_f64;
 const H_STD_INTERCEPT: f64 = 7.64006156_f64;
 const H_STD_COEF_1: f64 = 5.72612946_f64;
 const H_STD_COEF_2: f64 = -4.29283414_f64;
 
 // Away score simulator model weights
-const A_MEAN_INTERCEPT: f64 = 22.14952374_f64;
-const A_MEAN_COEF: f64 = 8.92113289_f64;
+const A_MEAN_COEF: f64 = 22.14952374_f64;
+const A_MEAN_INTERCEPT: f64 = 8.92113289_f64;
 const A_STD_INTERCEPT: f64 = 6.47638621_f64;
 const A_STD_COEF_1: f64 = 8.00861267_f64;
 const A_STD_COEF_2: f64 = -5.589282_f64;


### PR DESCRIPTION
While validating the box score generator model, I noticed that as the skill differentials decreased (for both home and away) were too high.

```
Home score distribution:
Skill Diff  Mean Score  Std Score
-100        23.1113     7.7145
-80         24.1988     8.2116
-60         25.3073     8.6825
-40         26.4093     9.0158
-20         27.5173     9.3168
0           28.6511     9.4955
20          29.8029     9.6095
40          30.8594     9.6051
60          31.9468     9.5214
80          33.0976     9.3920
100         34.2190     9.0957

Away score distribution:
Skill Diff  Mean Score  Std Score
-100        22.0837     6.5351
-80         22.9736     7.2503
-60         23.8552     7.9056
-40         24.7485     8.3959
-20         25.6754     8.8144
0           26.5304     9.1220
20          27.4934     9.3316
40          28.3558     9.4278
60          29.2878     9.3743
80          30.2001     9.2251
100         31.0693     8.9842
```

Upon reading through the source code, I noticed that the issue was that the intercept and coefficient of the model were actually backward.  So in this PR, I swap them in hopes of achieving a better fit.