### PR TITLE
perf: store score freq lut as static ref, use hashmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,8 +282,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbsim-core"
-version = "1.0.0-alpha.13"
+version = "1.0.0-alpha.14"
 dependencies = [
+ "lazy_static",
  "rand",
  "rand_distr",
  "rocket_okapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fbsim-core"
-version = "1.0.0-alpha.13"
+version = "1.0.0-alpha.14"
 authors = ["whatsacomputertho"]
 edition = "2021"
 description = "A library for american football simulation"
@@ -14,6 +14,7 @@ categories = ["games","simulation"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+lazy_static = "1.5.0"
 rand = "0.8.5"
 rand_distr = "0.4.3"
 rocket_okapi = { version = "0.9.0", features = ["swagger"], optional = true }

--- a/src/freq.rs
+++ b/src/freq.rs
@@ -1,14 +1,14 @@
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 
 pub struct ScoreFrequencyLookup {
-    freq_lookup: BTreeMap<i32, i32>,
+    freq_lookup: HashMap<i32, i32>,
 }
 
 impl ScoreFrequencyLookup {
     /// Constructor for the ScoreFrequencyLookup struct
     pub fn new() -> ScoreFrequencyLookup {
         ScoreFrequencyLookup{
-            freq_lookup: BTreeMap::new()
+            freq_lookup: HashMap::new()
         }
     }
 

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -1,3 +1,4 @@
+use lazy_static::lazy_static;
 use rand::Rng;
 use rand_distr::{Normal, Distribution, Bernoulli};
 use statrs::distribution::Categorical;
@@ -24,6 +25,15 @@ const A_STD_COEF_2: f64 = -5.589282_f64;
 const P_TIE_COEF: f64 = -0.00752297_f64;
 const P_TIE_INTERCEPT: f64 = 0.01055039_f64;
 const P_TIE_BASE: f64 = 0.036_f64;
+
+// Score frequency distribution
+lazy_static!{
+    static ref SCORE_FREQ_LUT: ScoreFrequencyLookup = {
+        let mut tmp_lut = ScoreFrequencyLookup::new();
+        tmp_lut.create();
+        tmp_lut
+    };
+}
 
 /// # `BoxScoreSimulator` struct
 ///
@@ -153,14 +163,10 @@ impl BoxScoreSimulator {
             return 0
         }
 
-        // Create a score frequency lookup table
-        let mut freq_lut = ScoreFrequencyLookup::new();
-        freq_lut.create();
-
         // Get the nearest neighbors of the score
-        let low = freq_lut.frequency(score - 1).unwrap();
-        let mid = freq_lut.frequency(score).unwrap();
-        let high = freq_lut.frequency(score + 1).unwrap();
+        let low = SCORE_FREQ_LUT.frequency(score - 1).unwrap();
+        let mid = SCORE_FREQ_LUT.frequency(score).unwrap();
+        let high = SCORE_FREQ_LUT.frequency(score + 1).unwrap();
         
         // Construct a categorical distribution
         let dist = Categorical::new(&[low as f64, mid as f64, high as f64]).unwrap();


### PR DESCRIPTION
In this PR, I improve the performance of the score frequency filtering by storing the LUT as a static ref, and not allocating it every time we run a sim.  I also switch to a HashMap for the LUT which has better lookup performance of O(1) versus O(log n).