### PR TITLE
feat(matchups): ability to summarize team performance over seasons

### DIFF
--- a/src/league.rs
+++ b/src/league.rs
@@ -1,10 +1,11 @@
-pub mod matchups;
+pub mod matchup;
 pub mod season;
 pub mod team;
 
-use crate::league::matchups::LeagueMatchups;
+use crate::league::matchup::LeagueMatchups;
 use crate::league::team::LeagueTeam;
 use crate::league::season::{LeagueSeason, LeagueSeasonScheduleOptions};
+use crate::league::season::matchup::LeagueSeasonMatchups;
 use crate::league::season::team::LeagueSeasonTeam;
 
 use std::collections::BTreeMap;
@@ -520,8 +521,8 @@ impl League {
     /// ### Example
     /// ```
     /// use fbsim_core::league::League;
-    /// use fbsim_core::league::matchups::LeagueMatchups;
     /// use fbsim_core::league::season::LeagueSeasonScheduleOptions;
+    /// use fbsim_core::league::season::matchup::LeagueSeasonMatchups;
     /// use fbsim_core::league::season::team::LeagueSeasonTeam;
     ///
     /// // Instantiate a new League
@@ -550,9 +551,9 @@ impl League {
     /// my_league.sim(&mut rng);
     ///
     /// // Get the season matchups for team 0
-    /// let matchups: LeagueMatchups = my_league.team_season_matchups(0, 2025).unwrap();
+    /// let matchups: LeagueSeasonMatchups = my_league.team_season_matchups(0, 2025).unwrap();
     /// ```
-    pub fn team_season_matchups(&self, id: usize, year: usize) -> Result<LeagueMatchups, String> {
+    pub fn team_season_matchups(&self, id: usize, year: usize) -> Result<LeagueSeasonMatchups, String> {
         // Ensure the team ID exists
         let _team = match self.team(id) {
             Some(t) => t,
@@ -585,7 +586,7 @@ impl League {
     /// ```
     /// use std::collections::BTreeMap;
     /// use fbsim_core::league::League;
-    /// use fbsim_core::league::matchups::LeagueMatchups;
+    /// use fbsim_core::league::matchup::LeagueMatchups;
     /// use fbsim_core::league::season::LeagueSeasonScheduleOptions;
     /// use fbsim_core::league::season::team::LeagueSeasonTeam;
     ///
@@ -615,11 +616,11 @@ impl League {
     /// my_league.sim(&mut rng);
     ///
     /// // Get the season matchups for team 0
-    /// let matchups: BTreeMap<usize, LeagueMatchups> = my_league.team_matchups(0);
+    /// let matchups: LeagueMatchups = my_league.team_matchups(0);
     /// ```
-    pub fn team_matchups(&self, id: usize) -> BTreeMap<usize, LeagueMatchups> {
+    pub fn team_matchups(&self, id: usize) -> LeagueMatchups {
         // Initialize a map of all of the team's season matchups
-        let mut matchups: BTreeMap<usize, LeagueMatchups> = BTreeMap::new();
+        let mut matchups: BTreeMap<usize, LeagueSeasonMatchups> = BTreeMap::new();
 
         // For the current season, get the team's season matchups
         match self.current_season() {
@@ -648,7 +649,7 @@ impl League {
             }
         }
 
-        // Return the map of matchups
-        matchups
+        // Return the matchups as a LeagueMatchups struct
+        LeagueMatchups::new(matchups)
     }
 }

--- a/src/league/matchup.rs
+++ b/src/league/matchup.rs
@@ -1,7 +1,7 @@
+use std::collections::BTreeMap;
 use std::fmt;
 
-use crate::matchup::FootballMatchupResult;
-use crate::league::season::matchup::LeagueSeasonMatchup;
+use crate::league::season::matchup::LeagueSeasonMatchups;
 
 /// # `LeagueTeamRecord` type
 ///
@@ -19,7 +19,7 @@ impl LeagueTeamRecord {
     ///
     /// ### Example
     /// ```
-    /// use fbsim_core::league::matchups::LeagueTeamRecord;
+    /// use fbsim_core::league::matchup::LeagueTeamRecord;
     ///
     /// let my_record = LeagueTeamRecord::new();
     /// ```
@@ -35,7 +35,7 @@ impl LeagueTeamRecord {
     ///
     /// ### Example
     /// ```
-    /// use fbsim_core::league::matchups::LeagueTeamRecord;
+    /// use fbsim_core::league::matchup::LeagueTeamRecord;
     ///
     /// let my_record = LeagueTeamRecord::new();
     /// let wins = my_record.wins();
@@ -49,22 +49,22 @@ impl LeagueTeamRecord {
     ///
     /// ### Example
     /// ```
-    /// use fbsim_core::league::matchups::LeagueTeamRecord;
+    /// use fbsim_core::league::matchup::LeagueTeamRecord;
     ///
     /// let mut my_record = LeagueTeamRecord::new();
-    /// my_record.increment_wins();
+    /// my_record.increment_wins(1);
     /// let wins = my_record.wins();
     /// assert!(*wins == 1);
     /// ```
-    pub fn increment_wins(&mut self) {
-        self.wins += 1
+    pub fn increment_wins(&mut self, n: usize) {
+        self.wins += n
     }
 
     /// Borrow the loss count
     ///
     /// ### Example
     /// ```
-    /// use fbsim_core::league::matchups::LeagueTeamRecord;
+    /// use fbsim_core::league::matchup::LeagueTeamRecord;
     ///
     /// let my_record = LeagueTeamRecord::new();
     /// let losses = my_record.losses();
@@ -78,22 +78,22 @@ impl LeagueTeamRecord {
     ///
     /// ### Example
     /// ```
-    /// use fbsim_core::league::matchups::LeagueTeamRecord;
+    /// use fbsim_core::league::matchup::LeagueTeamRecord;
     ///
     /// let mut my_record = LeagueTeamRecord::new();
-    /// my_record.increment_losses();
+    /// my_record.increment_losses(1);
     /// let losses = my_record.losses();
     /// assert!(*losses == 1);
     /// ```
-    pub fn increment_losses(&mut self) {
-        self.losses += 1
+    pub fn increment_losses(&mut self, n: usize) {
+        self.losses += n
     }
 
     /// Borrow the tie count
     ///
     /// ### Example
     /// ```
-    /// use fbsim_core::league::matchups::LeagueTeamRecord;
+    /// use fbsim_core::league::matchup::LeagueTeamRecord;
     ///
     /// let my_record = LeagueTeamRecord::new();
     /// let ties = my_record.ties();
@@ -107,15 +107,15 @@ impl LeagueTeamRecord {
     ///
     /// ### Example
     /// ```
-    /// use fbsim_core::league::matchups::LeagueTeamRecord;
+    /// use fbsim_core::league::matchup::LeagueTeamRecord;
     ///
     /// let mut my_record = LeagueTeamRecord::new();
-    /// my_record.increment_ties();
+    /// my_record.increment_ties(1);
     /// let ties = my_record.ties();
     /// assert!(*ties == 1);
     /// ```
-    pub fn increment_ties(&mut self) {
-        self.ties += 1
+    pub fn increment_ties(&mut self, n: usize) {
+        self.ties += n
     }
 }
 
@@ -130,34 +130,48 @@ impl fmt::Display for LeagueTeamRecord {
 ///
 /// Represents a list of matchups for a given team during a given season
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
-pub struct LeagueMatchups<'a> {
-    team_id: usize,
-    matchups: Vec<Option<&'a LeagueSeasonMatchup>>
+pub struct LeagueMatchups {
+    matchups: BTreeMap<usize, LeagueSeasonMatchups>
 }
 
-impl<'a> LeagueMatchups<'a> {
+impl LeagueMatchups {
     /// Instantiate a new LeagueMatchups struct
     ///
     /// ### Example
     /// ```
-    /// use fbsim_core::league::matchups::LeagueMatchups;
+    /// use std::collections::BTreeMap;
+    /// use fbsim_core::league::matchup::LeagueMatchups;
     ///
-    /// let my_matchups = LeagueMatchups::new(0, Vec::new());
+    /// let my_matchups = LeagueMatchups::new(BTreeMap::new());
     /// ```
-    pub fn new(team_id: usize, matchups: Vec<Option<&'a LeagueSeasonMatchup>>) -> LeagueMatchups {
+    pub fn new(matchups: BTreeMap<usize, LeagueSeasonMatchups>) -> LeagueMatchups {
         LeagueMatchups{
-            team_id: team_id,
             matchups: matchups
         }
+    }
+
+    /// Borrow the season matchups
+    ///
+    /// ### Example
+    /// ```
+    /// use std::collections::BTreeMap;
+    /// use fbsim_core::league::matchup::LeagueMatchups;
+    /// 
+    /// let my_matchups = LeagueMatchups::new(BTreeMap::new());
+    /// let matchups = my_matchups.matchups();
+    /// ```
+    pub fn matchups(&self) -> &BTreeMap<usize, LeagueSeasonMatchups> {
+        &self.matchups
     }
 
     /// Compute the team record
     ///
     /// ### Example
     /// ```
-    /// use fbsim_core::league::matchups::{LeagueMatchups, LeagueTeamRecord};
+    /// use std::collections::BTreeMap;
+    /// use fbsim_core::league::matchup::{LeagueMatchups, LeagueTeamRecord};
     ///
-    /// let my_matchups = LeagueMatchups::new(0, Vec::new());
+    /// let my_matchups = LeagueMatchups::new(BTreeMap::new());
     /// let record = my_matchups.record();
     /// assert!(record == LeagueTeamRecord::new());
     /// ```
@@ -166,18 +180,11 @@ impl<'a> LeagueMatchups<'a> {
         let mut record = LeagueTeamRecord::new();
 
         // Loop through the matchups and increment the team record
-        for matchup in self.matchups.iter() {
-            match matchup {
-                Some(m) => match m.result(self.team_id) {
-                    Some(r) => match r {
-                        FootballMatchupResult::Win => record.increment_wins(),
-                        FootballMatchupResult::Loss => record.increment_losses(),
-                        FootballMatchupResult::Tie => record.increment_ties()
-                    },
-                    None => ()
-                },
-                None => ()
-            }
+        for (_, season) in self.matchups.iter() {
+            let season_record = season.record();
+            record.increment_wins(*season_record.wins());
+            record.increment_losses(*season_record.losses());
+            record.increment_ties(*season_record.ties());
         }
         record
     }

--- a/src/league/matchups.rs
+++ b/src/league/matchups.rs
@@ -1,0 +1,184 @@
+use std::fmt;
+
+use crate::matchup::FootballMatchupResult;
+use crate::league::season::matchup::LeagueSeasonMatchup;
+
+/// # `LeagueTeamRecord` type
+///
+/// A 3-tuple of usizes representing the number of wins, losses, and ties
+/// for a given team.  May be for a season or for many seasons.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+pub struct LeagueTeamRecord {
+    wins: usize,
+    losses: usize,
+    ties: usize
+}
+
+impl LeagueTeamRecord {
+    /// Constructor for the LeagueTeamRecord type
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::matchups::LeagueTeamRecord;
+    ///
+    /// let my_record = LeagueTeamRecord::new();
+    /// ```
+    pub fn new() -> LeagueTeamRecord {
+        LeagueTeamRecord{
+            wins: 0,
+            losses: 0,
+            ties: 0
+        }
+    }
+
+    /// Borrow the win count
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::matchups::LeagueTeamRecord;
+    ///
+    /// let my_record = LeagueTeamRecord::new();
+    /// let wins = my_record.wins();
+    /// assert!(*wins == 0);
+    /// ```
+    pub fn wins(&self) -> &usize {
+        &self.wins
+    }
+
+    /// Increment the win count
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::matchups::LeagueTeamRecord;
+    ///
+    /// let mut my_record = LeagueTeamRecord::new();
+    /// my_record.increment_wins();
+    /// let wins = my_record.wins();
+    /// assert!(*wins == 1);
+    /// ```
+    pub fn increment_wins(&mut self) {
+        self.wins += 1
+    }
+
+    /// Borrow the loss count
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::matchups::LeagueTeamRecord;
+    ///
+    /// let my_record = LeagueTeamRecord::new();
+    /// let losses = my_record.losses();
+    /// assert!(*losses == 0);
+    /// ```
+    pub fn losses(&self) -> &usize {
+        &self.losses
+    }
+
+    /// Increment the loss count
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::matchups::LeagueTeamRecord;
+    ///
+    /// let mut my_record = LeagueTeamRecord::new();
+    /// my_record.increment_losses();
+    /// let losses = my_record.losses();
+    /// assert!(*losses == 1);
+    /// ```
+    pub fn increment_losses(&mut self) {
+        self.losses += 1
+    }
+
+    /// Borrow the tie count
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::matchups::LeagueTeamRecord;
+    ///
+    /// let my_record = LeagueTeamRecord::new();
+    /// let ties = my_record.ties();
+    /// assert!(*ties == 0);
+    /// ```
+    pub fn ties(&self) -> &usize {
+        &self.ties
+    }
+
+    /// Increment the tie count
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::matchups::LeagueTeamRecord;
+    ///
+    /// let mut my_record = LeagueTeamRecord::new();
+    /// my_record.increment_ties();
+    /// let ties = my_record.ties();
+    /// assert!(*ties == 1);
+    /// ```
+    pub fn increment_ties(&mut self) {
+        self.ties += 1
+    }
+}
+
+impl fmt::Display for LeagueTeamRecord {
+    /// Display a LeagueTeamRecord as a string
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}-{}-{}", self.wins, self.losses, self.ties)
+    }
+}
+
+/// # `LeagueMatchups` struct
+///
+/// Represents a list of matchups for a given team during a given season
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+pub struct LeagueMatchups<'a> {
+    team_id: usize,
+    matchups: Vec<Option<&'a LeagueSeasonMatchup>>
+}
+
+impl<'a> LeagueMatchups<'a> {
+    /// Instantiate a new LeagueMatchups struct
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::matchups::LeagueMatchups;
+    ///
+    /// let my_matchups = LeagueMatchups::new(0, Vec::new());
+    /// ```
+    pub fn new(team_id: usize, matchups: Vec<Option<&'a LeagueSeasonMatchup>>) -> LeagueMatchups {
+        LeagueMatchups{
+            team_id: team_id,
+            matchups: matchups
+        }
+    }
+
+    /// Compute the team record
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::matchups::{LeagueMatchups, LeagueTeamRecord};
+    ///
+    /// let my_matchups = LeagueMatchups::new(0, Vec::new());
+    /// let record = my_matchups.record();
+    /// assert!(record == LeagueTeamRecord::new());
+    /// ```
+    pub fn record(&self) -> LeagueTeamRecord {
+        // Initialize a new LeagueTeamRecord
+        let mut record = LeagueTeamRecord::new();
+
+        // Loop through the matchups and increment the team record
+        for matchup in self.matchups.iter() {
+            match matchup {
+                Some(m) => match m.result(self.team_id) {
+                    Some(r) => match r {
+                        FootballMatchupResult::Win => record.increment_wins(),
+                        FootballMatchupResult::Loss => record.increment_losses(),
+                        FootballMatchupResult::Tie => record.increment_ties()
+                    },
+                    None => ()
+                },
+                None => ()
+            }
+        }
+        record
+    }
+}

--- a/src/league/season.rs
+++ b/src/league/season.rs
@@ -4,10 +4,9 @@ pub mod week;
 
 use std::collections::BTreeMap;
 
-use crate::league::matchups::LeagueMatchups;
 use crate::league::season::team::LeagueSeasonTeam;
 use crate::league::season::week::LeagueSeasonWeek;
-use crate::league::season::matchup::LeagueSeasonMatchup;
+use crate::league::season::matchup::{LeagueSeasonMatchup, LeagueSeasonMatchups};
 use crate::sim::BoxScoreSimulator;
 use crate::team::FootballTeam;
 
@@ -659,7 +658,7 @@ impl LeagueSeason {
                     ),
                 };
                 let matchup = LeagueSeasonMatchup::new(*home_id, *away_id);
-                week.matchups_mut().push(matchup);
+                week.matchups_mut().push(matchup.into());
             }
 
             // Add the week to the season
@@ -959,9 +958,9 @@ impl LeagueSeason {
     ///
     /// ### Example
     /// ```
-    /// use fbsim_core::league::matchups::LeagueMatchups;
     /// use fbsim_core::league::season::LeagueSeason;
     /// use fbsim_core::league::season::LeagueSeasonScheduleOptions;
+    /// use fbsim_core::league::season::matchup::LeagueSeasonMatchups;
     /// use fbsim_core::league::season::team::LeagueSeasonTeam;
     ///
     /// // Create a new season
@@ -981,9 +980,9 @@ impl LeagueSeason {
     /// my_league_season.sim(&mut rng);
     ///
     /// // Get the mathups for team 0
-    /// let matchups: LeagueMatchups = my_league_season.team_matchups(0).unwrap();
+    /// let matchups: LeagueSeasonMatchups = my_league_season.team_matchups(0).unwrap();
     /// ```
-    pub fn team_matchups(&self, id: usize) -> Result<LeagueMatchups, String> {
+    pub fn team_matchups(&self, id: usize) -> Result<LeagueSeasonMatchups, String> {
         // Ensure the given team ID exists
         let _team = match self.team(id) {
             Some(t) => t,
@@ -996,11 +995,11 @@ impl LeagueSeason {
         };
 
         // Construct the matchups vector
-        let mut matchups: Vec<Option<&LeagueSeasonMatchup>> = Vec::new();
+        let mut matchups: Vec<Option<LeagueSeasonMatchup>> = Vec::new();
         for week in self.weeks.iter() {
             matchups.push(week.team_matchup(id));
         }
-        Ok(LeagueMatchups::new(id, matchups))
+        Ok(LeagueSeasonMatchups::new(id, matchups))
     }
 }
 

--- a/src/league/season.rs
+++ b/src/league/season.rs
@@ -4,6 +4,7 @@ pub mod week;
 
 use std::collections::BTreeMap;
 
+use crate::league::matchups::LeagueMatchups;
 use crate::league::season::team::LeagueSeasonTeam;
 use crate::league::season::week::LeagueSeasonWeek;
 use crate::league::season::matchup::LeagueSeasonMatchup;
@@ -952,6 +953,54 @@ impl LeagueSeason {
             }
         }
         Ok(())
+    }
+
+    /// Get all season matchups involving a team
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::matchups::LeagueMatchups;
+    /// use fbsim_core::league::season::LeagueSeason;
+    /// use fbsim_core::league::season::LeagueSeasonScheduleOptions;
+    /// use fbsim_core::league::season::team::LeagueSeasonTeam;
+    ///
+    /// // Create a new season
+    /// let mut my_league_season = LeagueSeason::new();
+    ///
+    /// // Add 4 teams to the season
+    /// my_league_season.add_team(0, LeagueSeasonTeam::new());
+    /// my_league_season.add_team(1, LeagueSeasonTeam::new());
+    /// my_league_season.add_team(2, LeagueSeasonTeam::new());
+    /// my_league_season.add_team(3, LeagueSeasonTeam::new());
+    ///
+    /// // Generate the season schedule
+    /// let mut rng = rand::thread_rng();
+    /// my_league_season.generate_schedule(LeagueSeasonScheduleOptions::new(), &mut rng);
+    ///
+    /// // Simulate the entire season
+    /// my_league_season.sim(&mut rng);
+    ///
+    /// // Get the mathups for team 0
+    /// let matchups: LeagueMatchups = my_league_season.team_matchups(0).unwrap();
+    /// ```
+    pub fn team_matchups(&self, id: usize) -> Result<LeagueMatchups, String> {
+        // Ensure the given team ID exists
+        let _team = match self.team(id) {
+            Some(t) => t,
+            None => return Err(
+                format!(
+                    "No team found with ID {} in season {}",
+                    id, self.year()
+                )
+            )
+        };
+
+        // Construct the matchups vector
+        let mut matchups: Vec<Option<&LeagueSeasonMatchup>> = Vec::new();
+        for week in self.weeks.iter() {
+            matchups.push(week.team_matchup(id));
+        }
+        Ok(LeagueMatchups::new(id, matchups))
     }
 }
 

--- a/src/league/season/matchup.rs
+++ b/src/league/season/matchup.rs
@@ -1,5 +1,7 @@
 use serde::{Serialize, Deserialize};
 
+use crate::matchup::FootballMatchupResult;
+
 /// # `LeagueSeasonMatchup` struct
 ///
 /// A `LeagueSeasonMatchup` represents a matchup during a week of a football season
@@ -134,5 +136,76 @@ impl LeagueSeasonMatchup {
     /// ```
     pub fn complete_mut(&mut self) -> &mut bool {
         &mut self.complete
+    }
+
+    /// Determine whether the given team participated in the matchup
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::matchup::LeagueSeasonMatchup;
+    ///
+    /// let mut my_matchup = LeagueSeasonMatchup::new(0, 1);
+    /// assert!(my_matchup.participated(0));
+    /// assert!(!my_matchup.participated(2));
+    /// ```
+    pub fn participated(&self, id: usize) -> bool {
+        if id == self.home_team || id == self.away_team {
+            return true;
+        }
+        false
+    }
+
+    /// Determine whether the given team was the home team in the matchup
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::matchup::LeagueSeasonMatchup;
+    ///
+    /// let mut my_matchup = LeagueSeasonMatchup::new(0, 1);
+    /// assert!(my_matchup.is_home_team(0));
+    /// assert!(!my_matchup.is_home_team(1));
+    /// assert!(!my_matchup.is_home_team(2));
+    /// ```
+    pub fn is_home_team(&self, id: usize) -> bool {
+        if id == self.home_team {
+            return true;
+        }
+        false
+    }
+
+    /// Determine whether the given team won, lost, or tied
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::matchup::LeagueSeasonMatchup;
+    ///
+    /// let mut my_matchup = LeagueSeasonMatchup::new(0, 1);
+    /// let res = my_matchup.result(0);
+    /// assert!(res.is_none());
+    /// ```
+    pub fn result(&self, id: usize) -> Option<FootballMatchupResult> {
+        // If the team did not participate or the game is not complete
+        // Then it has no result
+        if !(self.complete && self.participated(id)) {
+            return None;
+        }
+
+        // Calculate and return the result
+        if self.home_score == self.away_score {
+            return Some(FootballMatchupResult::Tie);
+        }
+        if self.is_home_team(id) {
+            if self.home_score > self.away_score {
+                return Some(FootballMatchupResult::Win);
+            } else {
+                return Some(FootballMatchupResult::Loss);
+            }
+        } else {
+            if self.home_score > self.away_score {
+                return Some(FootballMatchupResult::Loss);
+            } else {
+                return Some(FootballMatchupResult::Win);
+            }
+        }
     }
 }

--- a/src/league/season/matchup.rs
+++ b/src/league/season/matchup.rs
@@ -1,6 +1,7 @@
 use serde::{Serialize, Deserialize};
 
 use crate::matchup::FootballMatchupResult;
+use crate::league::matchup::LeagueTeamRecord;
 
 /// # `LeagueSeasonMatchup` struct
 ///
@@ -207,5 +208,76 @@ impl LeagueSeasonMatchup {
                 return Some(FootballMatchupResult::Win);
             }
         }
+    }
+}
+
+/// # `LeagueSeasonMatchups` struct
+///
+/// Represents a list of matchups for a given team during a given season
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+pub struct LeagueSeasonMatchups {
+    team_id: usize,
+    matchups: Vec<Option<LeagueSeasonMatchup>>
+}
+
+impl LeagueSeasonMatchups {
+    /// Instantiate a new LeagueSeasonMatchups struct
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::matchup::LeagueSeasonMatchups;
+    ///
+    /// let my_matchups = LeagueSeasonMatchups::new(0, Vec::new());
+    /// ```
+    pub fn new(team_id: usize, matchups: Vec<Option<LeagueSeasonMatchup>>) -> LeagueSeasonMatchups {
+        LeagueSeasonMatchups{
+            team_id: team_id,
+            matchups: matchups
+        }
+    }
+
+    /// Borrow the season matchups
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::matchup::LeagueSeasonMatchups;
+    /// 
+    /// let my_matchups = LeagueSeasonMatchups::new(0, Vec::new());
+    /// let matchups = my_matchups.matchups();
+    /// ```
+    pub fn matchups(&self) -> &Vec<Option<LeagueSeasonMatchup>> {
+        &self.matchups
+    }
+
+    /// Compute the team record
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::matchup::LeagueTeamRecord;
+    /// use fbsim_core::league::season::matchup::LeagueSeasonMatchups;
+    ///
+    /// let my_matchups = LeagueSeasonMatchups::new(0, Vec::new());
+    /// let record = my_matchups.record();
+    /// assert!(record == LeagueTeamRecord::new());
+    /// ```
+    pub fn record(&self) -> LeagueTeamRecord {
+        // Initialize a new LeagueTeamRecord
+        let mut record = LeagueTeamRecord::new();
+
+        // Loop through the matchups and increment the team record
+        for matchup in self.matchups.iter() {
+            match matchup {
+                Some(m) => match m.result(self.team_id) {
+                    Some(r) => match r {
+                        FootballMatchupResult::Win => record.increment_wins(1),
+                        FootballMatchupResult::Loss => record.increment_losses(1),
+                        FootballMatchupResult::Tie => record.increment_ties(1)
+                    },
+                    None => ()
+                },
+                None => ()
+            }
+        }
+        record
     }
 }

--- a/src/league/season/week.rs
+++ b/src/league/season/week.rs
@@ -99,4 +99,14 @@ impl LeagueSeasonWeek {
         }
         true
     }
+
+    /// Get a matchup involving a team
+    pub fn team_matchup(&self, id: usize) -> Option<&LeagueSeasonMatchup> {
+        for matchup in self.matchups.iter() {
+            if matchup.participated(id) {
+                return Some(&matchup);
+            }
+        }
+        return None
+    }
 }

--- a/src/league/season/week.rs
+++ b/src/league/season/week.rs
@@ -101,10 +101,10 @@ impl LeagueSeasonWeek {
     }
 
     /// Get a matchup involving a team
-    pub fn team_matchup(&self, id: usize) -> Option<&LeagueSeasonMatchup> {
+    pub fn team_matchup(&self, id: usize) -> Option<LeagueSeasonMatchup> {
         for matchup in self.matchups.iter() {
             if matchup.participated(id) {
-                return Some(&matchup);
+                return Some(matchup.clone());
             }
         }
         return None

--- a/src/matchup.rs
+++ b/src/matchup.rs
@@ -6,6 +6,15 @@ use serde::{Serialize, Deserialize};
 
 use crate::team::FootballTeam;
 
+/// # `FootballMatchupResult` enum
+///
+/// Represents a result (win, loss, tie) of a football game
+pub enum FootballMatchupResult {
+    Win,
+    Loss,
+    Tie,
+}
+
 /// # `FootballMatchup` struct
 ///
 /// A FootballMatchup represents a matchup between a home and away team


### PR DESCRIPTION
Adds the ability to get all matchups involving a team.  This will enable the CLI to summarize and visualize team performance over a season, and over many seasons.

For reference, see:
- https://github.com/whatsacomputertho/fbsim-cli/issues/9