### PR TITLE
feat(api): implement jsonschema trait for league structs

### DIFF
--- a/src/league.rs
+++ b/src/league.rs
@@ -10,6 +10,10 @@ use crate::league::season::team::LeagueSeasonTeam;
 
 use std::collections::BTreeMap;
 
+#[cfg(feature = "rocket_okapi")]
+use rocket_okapi::okapi::schemars;
+#[cfg(feature = "rocket_okapi")]
+use rocket_okapi::okapi::schemars::JsonSchema;
 use rand::Rng;
 use serde::{Serialize, Deserialize, Deserializer};
 
@@ -64,6 +68,7 @@ impl LeagueRaw {
 /// A `League` represents a football league. It contains a vector of teams in
 /// the league as `LeagueTeam` objects. It also contains the season that is
 /// currently in-progress, and it contains a vector of past seasons
+#[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize)]
 pub struct League {
     teams: BTreeMap<usize, LeagueTeam>,

--- a/src/league/season.rs
+++ b/src/league/season.rs
@@ -10,6 +10,10 @@ use crate::league::season::matchup::{LeagueSeasonMatchup, LeagueSeasonMatchups};
 use crate::sim::BoxScoreSimulator;
 use crate::team::FootballTeam;
 
+#[cfg(feature = "rocket_okapi")]
+use rocket_okapi::okapi::schemars;
+#[cfg(feature = "rocket_okapi")]
+use rocket_okapi::okapi::schemars::JsonSchema;
 use chrono::Datelike;
 use rand::Rng;
 use rand::seq::SliceRandom;
@@ -265,6 +269,7 @@ impl LeagueSeasonScheduleOptions {
 /// # `LeagueSeason` struct
 ///
 /// A `LeagueSeason` represents a season of a football league.
+#[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize)]
 pub struct LeagueSeason {
     year: usize,

--- a/src/league/season/matchup.rs
+++ b/src/league/season/matchup.rs
@@ -1,3 +1,7 @@
+#[cfg(feature = "rocket_okapi")]
+use rocket_okapi::okapi::schemars;
+#[cfg(feature = "rocket_okapi")]
+use rocket_okapi::okapi::schemars::JsonSchema;
 use serde::{Serialize, Deserialize};
 
 use crate::matchup::FootballMatchupResult;
@@ -6,6 +10,7 @@ use crate::league::matchup::LeagueTeamRecord;
 /// # `LeagueSeasonMatchup` struct
 ///
 /// A `LeagueSeasonMatchup` represents a matchup during a week of a football season
+#[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize, Deserialize)]
 pub struct LeagueSeasonMatchup {
     home_team: usize,

--- a/src/league/season/team.rs
+++ b/src/league/season/team.rs
@@ -1,3 +1,7 @@
+#[cfg(feature = "rocket_okapi")]
+use rocket_okapi::okapi::schemars;
+#[cfg(feature = "rocket_okapi")]
+use rocket_okapi::okapi::schemars::JsonSchema;
 use serde::{Serialize, Deserialize, Deserializer};
 
 use crate::team::DEFAULT_TEAM_NAME;
@@ -40,6 +44,7 @@ impl LeagueSeasonTeamRaw {
 /// # `LeagueSeasonTeam` struct
 ///
 /// A `LeagueSeasonTeam` represents a team during a season of a football leauge
+#[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize)]
 pub struct LeagueSeasonTeam {
     name: String,

--- a/src/league/season/week.rs
+++ b/src/league/season/week.rs
@@ -1,3 +1,7 @@
+#[cfg(feature = "rocket_okapi")]
+use rocket_okapi::okapi::schemars;
+#[cfg(feature = "rocket_okapi")]
+use rocket_okapi::okapi::schemars::JsonSchema;
 use serde::{Serialize, Deserialize};
 
 use crate::league::season::matchup::LeagueSeasonMatchup;
@@ -5,6 +9,7 @@ use crate::league::season::matchup::LeagueSeasonMatchup;
 /// # `LeagueSeasonWeek` struct
 ///
 /// A `LeagueSeasonWeek` represents a week of a football season
+#[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize, Deserialize)]
 pub struct LeagueSeasonWeek {
     matchups: Vec<LeagueSeasonMatchup>

--- a/src/league/team.rs
+++ b/src/league/team.rs
@@ -1,11 +1,17 @@
 use serde::{Serialize, Deserialize};
 
+#[cfg(feature = "rocket_okapi")]
+use rocket_okapi::okapi::schemars;
+#[cfg(feature = "rocket_okapi")]
+use rocket_okapi::okapi::schemars::JsonSchema;
+
 /// # `LeagueTeam` struct
 ///
 /// A `LeagueTeam` represents a football team in a football league.
 /// Since a team's properties (skill levels, team name, etc.) can change
 /// over the course of many seasons, this struct is mainly just used
 /// as a unique ID for a given team
+#[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize, Deserialize)]
 pub struct LeagueTeam {}
 


### PR DESCRIPTION
When the `rocket_okapi` feature flag is set, this sets the `JsonSchema` trait from rocket okapi on the `League` struct and its sub-structs.

For reference, see:
- https://github.com/whatsacomputertho/fbsim-core/issues/28