### PR TITLE
feat(pbp): improved pass model, validation & builder patterns

### DIFF
--- a/src/game/play/context.rs
+++ b/src/game/play/context.rs
@@ -36,38 +36,38 @@ impl From<&GameContext> for PlayContext {
     /// ```
     fn from(item: &GameContext) -> PlayContext {
         // Determine score diff and timeouts based on possession
-        let score_diff: i32 = if *item.home_possession() {
-            *item.home_score() as i32 - *item.away_score() as i32
+        let score_diff: i32 = if item.home_possession() {
+            item.home_score() as i32 - item.away_score() as i32
         } else {
-            *item.away_score() as i32 - *item.home_score() as i32
+            item.away_score() as i32 - item.home_score() as i32
         };
-        let off_timeouts: u32 = if *item.home_possession() {
-            *item.home_timeouts()
+        let off_timeouts: u32 = if item.home_possession() {
+            item.home_timeouts()
         } else {
-            *item.away_timeouts()
+            item.away_timeouts()
         };
-        let def_timeouts: u32 = if *item.home_possession() {
-            *item.away_timeouts()
+        let def_timeouts: u32 = if item.home_possession() {
+            item.away_timeouts()
         } else {
-            *item.home_timeouts()
+            item.home_timeouts()
         };
 
         // Determine yard line based on possession and direction
-        let yard_line: u32 = if *item.home_possession() ^ *item.home_positive_direction() {
-            match u32::try_from(100_i32 - *item.yard_line() as i32) {
+        let yard_line: u32 = if item.home_possession() ^ item.home_positive_direction() {
+            match u32::try_from(100_i32 - item.yard_line() as i32) {
                 Ok(n) => n,
                 Err(_) => 0
             }
         } else {
-            *item.yard_line()
+            item.yard_line()
         };
 
         // Construct the play context
         PlayContext{
-            quarter: *item.quarter(),
-            half_seconds: *item.half_seconds(),
-            down: *item.down(),
-            distance: *item.distance(),
+            quarter: item.quarter(),
+            half_seconds: item.half_seconds(),
+            down: item.down(),
+            distance: item.distance(),
             yard_line: yard_line,
             score_diff: score_diff,
             off_timeouts: off_timeouts,
@@ -422,7 +422,8 @@ impl std::fmt::Display for PlayContext {
     /// ```
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Format the clock
-        let clock_total = if self.half_seconds < 900 {
+        let clock_total = if self.half_seconds < 900 || 
+            (self.half_seconds == 900 && self.quarter % 2 == 0 && self.quarter <= 4) {
             self.half_seconds
         } else {
             self.half_seconds - 900

--- a/src/game/play/result.rs
+++ b/src/game/play/result.rs
@@ -39,6 +39,7 @@ pub trait PlayResult {
     fn out_of_bounds(&self) -> bool { false }
     fn touchback(&self) -> bool { false }
     fn kickoff(&self) -> bool { false }
+    fn punt(&self) -> bool { false }
     fn next_play_kickoff(&self) -> bool { false }
     fn next_play_extra_point(&self) -> bool { false }
 }
@@ -245,15 +246,29 @@ impl PlayResult for PlayTypeResult {
 
     fn kickoff(&self) -> bool {
         match self {
-            PlayTypeResult::BetweenPlay(res) => res.touchback(),
-            PlayTypeResult::Run(res) => res.touchback(),
-            PlayTypeResult::Pass(res) => res.touchback(),
-            PlayTypeResult::FieldGoal(res) => res.touchback(),
-            PlayTypeResult::Punt(res) => res.touchback(),
-            PlayTypeResult::Kickoff(res) => res.touchback(),
-            PlayTypeResult::ExtraPoint(res) => res.touchback(),
-            PlayTypeResult::QbKneel(res) => res.touchback(),
-            PlayTypeResult::QbSpike(res) => res.touchback()
+            PlayTypeResult::BetweenPlay(res) => res.kickoff(),
+            PlayTypeResult::Run(res) => res.kickoff(),
+            PlayTypeResult::Pass(res) => res.kickoff(),
+            PlayTypeResult::FieldGoal(res) => res.kickoff(),
+            PlayTypeResult::Punt(res) => res.kickoff(),
+            PlayTypeResult::Kickoff(res) => res.kickoff(),
+            PlayTypeResult::ExtraPoint(res) => res.kickoff(),
+            PlayTypeResult::QbKneel(res) => res.kickoff(),
+            PlayTypeResult::QbSpike(res) => res.kickoff()
+        }
+    }
+
+    fn punt(&self) -> bool {
+        match self {
+            PlayTypeResult::BetweenPlay(res) => res.punt(),
+            PlayTypeResult::Run(res) => res.punt(),
+            PlayTypeResult::Pass(res) => res.punt(),
+            PlayTypeResult::FieldGoal(res) => res.punt(),
+            PlayTypeResult::Punt(res) => res.punt(),
+            PlayTypeResult::Kickoff(res) => res.punt(),
+            PlayTypeResult::ExtraPoint(res) => res.punt(),
+            PlayTypeResult::QbKneel(res) => res.punt(),
+            PlayTypeResult::QbSpike(res) => res.punt()
         }
     }
 

--- a/src/game/play/result/fieldgoal.rs
+++ b/src/game/play/result/fieldgoal.rs
@@ -3,7 +3,7 @@ use rand::Rng;
 use rocket_okapi::okapi::schemars;
 #[cfg(feature = "rocket_okapi")]
 use rocket_okapi::okapi::schemars::JsonSchema;
-use serde::{Serialize, Deserialize};
+use serde::{Serialize, Deserialize, Deserializer};
 use rand_distr::{Distribution, Exp, SkewNormal};
 
 use crate::game::context::GameContext;
@@ -37,11 +37,93 @@ const FIELD_GOAL_NOT_BLOCKED_DURATION_MEAN: f64 = 7.054470_f64; // Adjusted + 3
 const FIELD_GOAL_NOT_BLOCKED_DURATION_STD: f64 = 1.001211_f64;
 const FIELD_GOAL_NOT_BLOCKED_DURATION_SKEW: f64 = -0.440028_f64;
 
+/// # `FieldGoalResultRaw` struct
+///
+/// A `FieldGoalResultRaw` is a `FieldGoalResult` before its properties
+/// have been validated
+#[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize, Deserialize)]
+pub struct FieldGoalResultRaw {
+    field_goal_distance: i32,
+    return_yards: i32,
+    play_duration: u32,
+    made: bool,
+    blocked: bool,
+    touchdown: bool,
+    extra_point: bool
+}
+
+impl FieldGoalResultRaw {
+    pub fn validate(&self) -> Result<(), String> {
+        // Ensure a field goal is not both made and TD scored
+        if self.made && self.touchdown {
+            return Err(
+                String::from("Field goal cannot both be made & TD scored")
+            )
+        }
+
+        // Ensure a field goal is not both made and blocked
+        if self.made && self.blocked {
+            return Err(
+                String::from("Field goal cannot both be made & blocked")
+            )
+        }
+
+        // Ensure a TD is not scored if a field goal is not blocked
+        if self.touchdown && !self.blocked {
+            return Err(
+                String::from("Field goal cannot result in TD if not blocked")
+            )
+        }
+
+        // Ensure a field goal is not longer than 117 yards
+        if self.field_goal_distance > 117 {
+            return Err(
+                format!(
+                    "Field goal distance is out of range [0, 117]: {}",
+                    self.field_goal_distance
+                )
+            )
+        }
+
+        // Ensure a field goal play does not last longer than 100 seconds
+        if self.play_duration > 100 {
+            return Err(
+                format!(
+                    "Play duration is out of range [0, 100]: {}",
+                    self.play_duration
+                ),
+            )
+        }
+
+        // Ensure return yards are in range [-100, 100]
+        if self.return_yards.abs() > 100 {
+            return Err(
+                format!(
+                    "Return yards is out of range [-100, 100]: {}",
+                    self.return_yards
+                )
+            )
+        }
+
+        // Ensure zero return yards if field goal is not blocked
+        if !self.blocked && self.return_yards != 0 {
+            return Err(
+                format!(
+                    "Field goal was not blocked but return yards are nonzero: {}",
+                    self.return_yards
+                )
+            )
+        }
+        Ok(())
+    }
+}
+
 /// # `FieldGoalResult` struct
 ///
 /// A `FieldGoalResult` represents a result of a field goal
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
-#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize)]
 pub struct FieldGoalResult {
     field_goal_distance: i32,
     return_yards: i32,
@@ -50,6 +132,42 @@ pub struct FieldGoalResult {
     blocked: bool,
     touchdown: bool,
     extra_point: bool
+}
+
+impl TryFrom<FieldGoalResultRaw> for FieldGoalResult {
+    type Error = String;
+
+    fn try_from(item: FieldGoalResultRaw) -> Result<Self, Self::Error> {
+        // Validate the raw between play result
+        match item.validate() {
+            Ok(()) => (),
+            Err(error) => return Err(error),
+        };
+
+        // If valid, then convert
+        Ok(
+            FieldGoalResult{
+                field_goal_distance: item.field_goal_distance,
+                return_yards: item.return_yards,
+                play_duration: item.play_duration,
+                made: item.made,
+                blocked: item.blocked,
+                touchdown: item.touchdown,
+                extra_point: item.extra_point
+            }
+        )
+    }
+}
+
+impl<'de> Deserialize<'de> for FieldGoalResult {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Only deserialize if the conversion from raw succeeds
+        let raw = FieldGoalResultRaw::deserialize(deserializer)?;
+        FieldGoalResult::try_from(raw).map_err(serde::de::Error::custom)
+    }
 }
 
 impl Default for FieldGoalResult {
@@ -126,7 +244,11 @@ impl PlayResult for FieldGoalResult {
     }
 
     fn play_duration(&self) -> u32 {
-        self.play_duration
+        if self.extra_point {
+            0
+        } else {
+            self.play_duration
+        }
     }
 
     fn net_yards(&self) -> i32 {
@@ -243,6 +365,20 @@ impl FieldGoalResult {
         self.made
     }
 
+    /// Determine if a field goal was missed
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::fieldgoal::FieldGoalResult;
+    /// 
+    /// let my_res = FieldGoalResult::new();
+    /// let missed = my_res.missed();
+    /// assert!(!missed);
+    /// ```
+    pub fn missed(&self) -> bool {
+        !(self.made || self.blocked)
+    }
+
     /// Get a field goal result's blocked property
     ///
     /// ### Example
@@ -283,6 +419,205 @@ impl FieldGoalResult {
     /// ```
     pub fn extra_point(&self) -> bool {
         self.extra_point
+    }
+}
+
+/// # `FieldGoalResultBuilder` struct
+///
+/// A `FieldGoalResultBuilder` is a builder pattern implementation for the
+/// `FieldGoalResult` struct
+#[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize)]
+pub struct FieldGoalResultBuilder {
+    field_goal_distance: i32,
+    return_yards: i32,
+    play_duration: u32,
+    made: bool,
+    blocked: bool,
+    touchdown: bool,
+    extra_point: bool
+}
+
+impl Default for FieldGoalResultBuilder {
+    /// Default constructor for the FieldGoalResultBuilder class
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::fieldgoal::FieldGoalResultBuilder;
+    /// 
+    /// let my_result = FieldGoalResultBuilder::default();
+    /// ```
+    fn default() -> Self {
+        FieldGoalResultBuilder{
+            field_goal_distance: 17,
+            return_yards: 0,
+            play_duration: 0,
+            made: true,
+            blocked: false,
+            touchdown: false,
+            extra_point: true
+        }
+    }
+}
+
+impl FieldGoalResultBuilder {
+    /// Initialize a new FieldGoalResultBuilder
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::fieldgoal::FieldGoalResultBuilder;
+    /// 
+    /// let my_builder = FieldGoalResultBuilder::new();
+    /// ```
+    pub fn new() -> FieldGoalResultBuilder {
+        FieldGoalResultBuilder::default()
+    }
+
+    /// Set the field_goal_distance property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::fieldgoal::FieldGoalResultBuilder;
+    /// 
+    /// let my_result = FieldGoalResultBuilder::new()
+    ///     .field_goal_distance(53)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(my_result.field_goal_distance() == 53);
+    /// ```
+    pub fn field_goal_distance(mut self, field_goal_distance: i32) -> Self {
+        self.field_goal_distance = field_goal_distance;
+        self
+    }
+
+    /// Set the return_yards property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::fieldgoal::FieldGoalResultBuilder;
+    /// 
+    /// let my_result = FieldGoalResultBuilder::new()
+    ///     .made(false)
+    ///     .blocked(true)
+    ///     .return_yards(3)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(my_result.return_yards() == 3);
+    /// ```
+    pub fn return_yards(mut self, return_yards: i32) -> Self {
+        self.return_yards = return_yards;
+        self
+    }
+
+    /// Set the play_duration property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::fieldgoal::FieldGoalResultBuilder;
+    /// 
+    /// let my_result = FieldGoalResultBuilder::new()
+    ///     .play_duration(3)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(my_result.play_duration() == 3);
+    /// ```
+    pub fn play_duration(mut self, play_duration: u32) -> Self {
+        self.play_duration = play_duration;
+        self
+    }
+
+    /// Set the made property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::fieldgoal::FieldGoalResultBuilder;
+    /// 
+    /// let my_result = FieldGoalResultBuilder::new()
+    ///     .made(false)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(!my_result.made());
+    /// ```
+    pub fn made(mut self, made: bool) -> Self {
+        self.made = made;
+        self
+    }
+
+    /// Set the blocked property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::fieldgoal::FieldGoalResultBuilder;
+    /// 
+    /// let my_result = FieldGoalResultBuilder::new()
+    ///     .made(false)
+    ///     .blocked(true)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(my_result.blocked());
+    /// ```
+    pub fn blocked(mut self, blocked: bool) -> Self {
+        self.blocked = blocked;
+        self
+    }
+
+    /// Set the touchdown property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::fieldgoal::FieldGoalResultBuilder;
+    /// 
+    /// let my_result = FieldGoalResultBuilder::new()
+    ///     .made(false)
+    ///     .blocked(true)
+    ///     .touchdown(true)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(my_result.touchdown());
+    /// ```
+    pub fn touchdown(mut self, touchdown: bool) -> Self {
+        self.touchdown = touchdown;
+        self
+    }
+
+    /// Set the extra_point property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::fieldgoal::FieldGoalResultBuilder;
+    /// 
+    /// let my_result = FieldGoalResultBuilder::new()
+    ///     .extra_point(true)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(my_result.extra_point());
+    /// ```
+    pub fn extra_point(mut self, extra_point: bool) -> Self {
+        self.extra_point = extra_point;
+        self
+    }
+
+    /// Build the FieldGoalResult
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::fieldgoal::FieldGoalResultBuilder;
+    /// 
+    /// let my_result = FieldGoalResultBuilder::new()
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn build(self) -> Result<FieldGoalResult, String> {
+        let raw = FieldGoalResultRaw{
+            field_goal_distance: self.field_goal_distance,
+            return_yards: self.return_yards,
+            play_duration: self.play_duration,
+            made: self.made,
+            blocked: self.blocked,
+            touchdown: self.touchdown,
+            extra_point: self.extra_point
+        };
+        FieldGoalResult::try_from(raw)
     }
 }
 
@@ -397,15 +732,16 @@ impl PlayResultSimulator for FieldGoalResultSimulator {
 
         // Determine if a touchdown occurred
         let touchdown: bool = blocked && (return_yards > safety_yards.abs());
-        let fg_res = FieldGoalResult{
+        let raw = FieldGoalResultRaw{
             field_goal_distance: td_yards + 17,
             return_yards: return_yards,
             play_duration: play_duration,
             made: made,
             blocked: blocked,
             touchdown: touchdown,
-            extra_point: *context.next_play_extra_point()
+            extra_point: context.next_play_extra_point()
         };
+        let fg_res = FieldGoalResult::try_from(raw).unwrap();
         PlayTypeResult::FieldGoal(fg_res)
     }
 }

--- a/src/game/play/result/punt.rs
+++ b/src/game/play/result/punt.rs
@@ -3,7 +3,7 @@ use rand::Rng;
 use rocket_okapi::okapi::schemars;
 #[cfg(feature = "rocket_okapi")]
 use rocket_okapi::okapi::schemars::JsonSchema;
-use serde::{Serialize, Deserialize};
+use serde::{Serialize, Deserialize, Deserializer};
 use rand_distr::{Normal, Distribution, Exp, SkewNormal};
 
 use crate::game::context::GameContext;
@@ -82,17 +82,139 @@ const SKEW_REL_RETURN_YARDS_COEF_2: f64 = -6.94528823_f64;
 
 // Fumble probability regression
 const P_FUMBLE_INTR: f64 = 0.0460047101408259_f64;
-const P_FUMBLE_COEF: f64 = -0.04389777_f64;
+const P_FUMBLE_COEF: f64 = -0.08389777_f64; // Adjusted - 0.04
 
 // Punt play duration regression
 const PUNT_PLAY_DURATION_INTR: f64 = 8.2792296_f64; // Adjusted + 3
 const PUNT_PLAY_DURATION_COEF: f64 = 0.09291598_f64;
 
+/// # `PuntResultRaw` struct
+///
+/// A `PuntResultRaw` is a `PuntResult` before its properties have been
+/// validated
+#[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize, Deserialize)]
+pub struct PuntResultRaw {
+    fumble_return_yards: i32,
+    punt_yards: i32,
+    punt_return_yards: i32,
+    play_duration: u32,
+    blocked: bool,
+    touchback: bool,
+    out_of_bounds: bool,
+    fair_catch: bool,
+    muffed: bool,
+    fumble: bool,
+    touchdown: bool
+}
+
+impl PuntResultRaw {
+    pub fn validate(&self) -> Result<(), String> {
+        // Ensure the play duration is not greater than 100 seconds
+        if self.play_duration > 100 {
+            return Err(
+                format!(
+                    "Play duration is not in range [0, 100]: {}",
+                    self.play_duration
+                )
+            )
+        }
+
+        // Ensure the fumble return yards are in range [-100, 100]
+        if self.fumble_return_yards.abs() > 100 {
+            return Err(
+                format!(
+                    "Fumble return yards is not in range [-100, 100]: {}",
+                    self.fumble_return_yards
+                )
+            )
+        }
+
+        // Ensure the fumble return yards are zero if a fumble did not occur
+        if !self.fumble && self.fumble_return_yards != 0 {
+            return Err(
+                format!(
+                    "Fumble did not occur but fumble return yards are nonzero: {}",
+                    self.fumble_return_yards
+                )
+            )
+        }
+
+        // Ensure the punt yards are in range [-100, 100]
+        if self.punt_yards.abs() > 100 {
+            return Err(
+                format!(
+                    "Punt yards is not in range [-100, 100]: {}",
+                    self.punt_yards
+                )
+            )
+        }
+
+        // Ensure the punt return yards are in range [-100, 100]
+        if self.punt_return_yards.abs() > 100 {
+            return Err(
+                format!(
+                    "Punt return yards is not in range [-100, 100]: {}",
+                    self.punt_return_yards
+                )
+            )
+        }
+
+        // Ensure punt return yards are zero if punt was not returned
+        if (self.blocked || self.out_of_bounds || self.touchback || self.fair_catch || self.muffed) && self.punt_return_yards != 0 {
+            return Err(
+                format!(
+                    "Punt was not returned but punt return yards were nonzero: {}",
+                    self.punt_return_yards
+                )
+            )
+        }
+
+        // Ensure if muffed, a fumble also occurred
+        if self.muffed && !self.fumble {
+            return Err(
+                String::from("Cannot have a muffed punt that was not also fumbled")
+            )
+        }
+
+        // Ensure if blocked, not also oob, touchback, fair catch, or muffed
+        if self.blocked && (self.out_of_bounds || self.touchback || self.fair_catch || self.muffed) {
+            return Err(
+                format!(
+                    "Cannot have both blocked punt and out of bounds ({}), touchback ({}), fair catch ({}), or muffed ({})",
+                    self.out_of_bounds, self.touchback, self.fair_catch, self.muffed
+                )
+            )
+        }
+
+        // Ensure if touchback, not also oob, fair catch, muffed, fumble, or TD
+        if self.touchback && (self.out_of_bounds || self.fair_catch || self.fumble || self.touchdown) {
+            return Err(
+                format!(
+                    "Cannot have both touchback and out of bounds ({}), fair catch ({}), fumble ({}), or touchdown ({})",
+                    self.out_of_bounds, self.fair_catch, self.fumble, self.touchdown
+                )
+            )
+        }
+
+        // Ensure if out of bounds, not also fair catch, muffed, fumble, or TD
+        if self.out_of_bounds && (self.fair_catch || self.muffed || self.fumble || self.touchdown) {
+            return Err(
+                format!(
+                    "Cannot have both punt out of bounds and fair catch ({}), muffed ({}), fumble ({}), or touchdown ({})",
+                    self.fair_catch, self.muffed, self.fumble, self.touchdown
+                )
+            )
+        }
+        Ok(())
+    }
+}
+
 /// # `PuntResult` struct
 ///
 /// A `PuntResult` represents a result of a punt play
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
-#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize)]
 pub struct PuntResult {
     fumble_return_yards: i32,
     punt_yards: i32,
@@ -105,6 +227,46 @@ pub struct PuntResult {
     muffed: bool,
     fumble: bool,
     touchdown: bool
+}
+
+impl TryFrom<PuntResultRaw> for PuntResult {
+    type Error = String;
+
+    fn try_from(item: PuntResultRaw) -> Result<Self, Self::Error> {
+        // Validate the raw between play result
+        match item.validate() {
+            Ok(()) => (),
+            Err(error) => return Err(error),
+        };
+
+        // If valid, then convert
+        Ok(
+            PuntResult{
+                fumble_return_yards: item.fumble_return_yards,
+                punt_yards: item.punt_yards,
+                punt_return_yards: item.punt_return_yards,
+                play_duration: item.play_duration,
+                blocked: item.blocked,
+                touchback: item.touchback,
+                out_of_bounds: item.out_of_bounds,
+                fair_catch: item.fair_catch,
+                muffed: item.muffed,
+                fumble: item.fumble,
+                touchdown: item.touchdown
+            }
+        )
+    }
+}
+
+impl<'de> Deserialize<'de> for PuntResult {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Only deserialize if the conversion from raw succeeds
+        let raw = PuntResultRaw::deserialize(deserializer)?;
+        PuntResult::try_from(raw).map_err(serde::de::Error::custom)
+    }
 }
 
 impl Default for PuntResult {
@@ -238,6 +400,8 @@ impl PlayResult for PuntResult {
     }
 
     fn kickoff(&self) -> bool { false }
+
+    fn punt(&self) -> bool { true }
 
     fn next_play_kickoff(&self) -> bool { false }
 
@@ -411,6 +575,282 @@ impl PuntResult {
     /// ```
     pub fn touchdown(&self) -> bool {
         self.touchdown
+    }
+}
+
+/// # `PuntResultBuilder` struct
+///
+/// A `PuntResultBuilder` is a builder pattern implementation for the
+/// `PuntResult` struct
+#[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize)]
+pub struct PuntResultBuilder {
+    fumble_return_yards: i32,
+    punt_yards: i32,
+    punt_return_yards: i32,
+    play_duration: u32,
+    blocked: bool,
+    touchback: bool,
+    out_of_bounds: bool,
+    fair_catch: bool,
+    muffed: bool,
+    fumble: bool,
+    touchdown: bool
+}
+
+impl Default for PuntResultBuilder {
+    /// Default constructor for the PuntResultBuilder class
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::punt::PuntResultBuilder;
+    /// 
+    /// let my_result = PuntResultBuilder::default();
+    /// ```
+    fn default() -> Self {
+        PuntResultBuilder{
+            fumble_return_yards: 0,
+            punt_yards: 0,
+            punt_return_yards: 0,
+            play_duration: 0,
+            blocked: false,
+            touchback: false,
+            out_of_bounds: false,
+            fair_catch: false,
+            muffed: false,
+            fumble: false,
+            touchdown: false
+        }
+    }
+}
+
+impl PuntResultBuilder {
+    /// Initialize a new PuntResultBuilder
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::punt::PuntResultBuilder;
+    /// 
+    /// let my_builder = PuntResultBuilder::new();
+    /// ```
+    pub fn new() -> PuntResultBuilder {
+        PuntResultBuilder::default()
+    }
+
+    /// Set the play_duration property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::punt::PuntResultBuilder;
+    /// 
+    /// let my_result = PuntResultBuilder::new()
+    ///     .play_duration(10)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(my_result.play_duration() == 10);
+    /// ```
+    pub fn play_duration(mut self, play_duration: u32) -> Self {
+        self.play_duration = play_duration;
+        self
+    }
+
+    /// Set the fumble_return_yards property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::punt::PuntResultBuilder;
+    /// 
+    /// let my_result = PuntResultBuilder::new()
+    ///     .fumble(true)
+    ///     .fumble_return_yards(4)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(my_result.fumble_return_yards() == 4);
+    /// ```
+    pub fn fumble_return_yards(mut self, fumble_return_yards: i32) -> Self {
+        self.fumble_return_yards = fumble_return_yards;
+        self
+    }
+
+    /// Set the punt_yards property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::punt::PuntResultBuilder;
+    /// 
+    /// let my_result = PuntResultBuilder::new()
+    ///     .punt_yards(41)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(my_result.punt_yards() == 41);
+    /// ```
+    pub fn punt_yards(mut self, punt_yards: i32) -> Self {
+        self.punt_yards = punt_yards;
+        self
+    }
+
+    /// Set the punt_return_yards property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::punt::PuntResultBuilder;
+    /// 
+    /// let my_result = PuntResultBuilder::new()
+    ///     .punt_return_yards(8)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(my_result.punt_return_yards() == 8);
+    /// ```
+    pub fn punt_return_yards(mut self, punt_return_yards: i32) -> Self {
+        self.punt_return_yards = punt_return_yards;
+        self
+    }
+
+    /// Set the blocked property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::punt::PuntResultBuilder;
+    /// 
+    /// let my_result = PuntResultBuilder::new()
+    ///     .blocked(true)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(my_result.blocked());
+    /// ```
+    pub fn blocked(mut self, blocked: bool) -> Self {
+        self.blocked = blocked;
+        self
+    }
+
+    /// Set the touchback property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::punt::PuntResultBuilder;
+    /// 
+    /// let my_result = PuntResultBuilder::new()
+    ///     .touchback(true)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(my_result.touchback());
+    /// ```
+    pub fn touchback(mut self, touchback: bool) -> Self {
+        self.touchback = touchback;
+        self
+    }
+
+    /// Set the out_of_bounds property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::punt::PuntResultBuilder;
+    /// 
+    /// let my_result = PuntResultBuilder::new()
+    ///     .out_of_bounds(true)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(my_result.out_of_bounds());
+    /// ```
+    pub fn out_of_bounds(mut self, out_of_bounds: bool) -> Self {
+        self.out_of_bounds = out_of_bounds;
+        self
+    }
+
+    /// Set the fair_catch property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::punt::PuntResultBuilder;
+    /// 
+    /// let my_result = PuntResultBuilder::new()
+    ///     .fair_catch(true)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(my_result.fair_catch());
+    /// ```
+    pub fn fair_catch(mut self, fair_catch: bool) -> Self {
+        self.fair_catch = fair_catch;
+        self
+    }
+
+    /// Set the muffed property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::punt::PuntResultBuilder;
+    /// 
+    /// let my_result = PuntResultBuilder::new()
+    ///     .fumble(true)
+    ///     .muffed(true)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(my_result.muffed());
+    /// ```
+    pub fn muffed(mut self, muffed: bool) -> Self {
+        self.muffed = muffed;
+        self
+    }
+
+    /// Set the fumble property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::punt::PuntResultBuilder;
+    /// 
+    /// let my_result = PuntResultBuilder::new()
+    ///     .fumble(true)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(my_result.fumble());
+    /// ```
+    pub fn fumble(mut self, fumble: bool) -> Self {
+        self.fumble = fumble;
+        self
+    }
+
+    /// Set the touchdown property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::punt::PuntResultBuilder;
+    /// 
+    /// let my_result = PuntResultBuilder::new()
+    ///     .touchdown(true)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(my_result.touchdown());
+    /// ```
+    pub fn touchdown(mut self, touchdown: bool) -> Self {
+        self.touchdown = touchdown;
+        self
+    }
+
+    /// Build the PuntResult
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::punt::PuntResultBuilder;
+    /// 
+    /// let my_result = PuntResultBuilder::new()
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn build(self) -> Result<PuntResult, String> {
+        let raw = PuntResultRaw{
+            fumble_return_yards: self.fumble_return_yards,
+            punt_yards: self.punt_yards,
+            punt_return_yards: self.punt_return_yards,
+            play_duration: self.play_duration,
+            blocked: self.blocked,
+            touchback: self.touchback,
+            out_of_bounds: self.out_of_bounds,
+            fair_catch: self.fair_catch,
+            muffed: self.muffed,
+            fumble: self.fumble,
+            touchdown: self.touchdown
+        };
+        PuntResult::try_from(raw)
     }
 }
 

--- a/src/game/play/result/run.rs
+++ b/src/game/play/result/run.rs
@@ -3,7 +3,7 @@ use rand::Rng;
 use rocket_okapi::okapi::schemars;
 #[cfg(feature = "rocket_okapi")]
 use rocket_okapi::okapi::schemars::JsonSchema;
-use serde::{Serialize, Deserialize};
+use serde::{Serialize, Deserialize, Deserializer};
 use rand_distr::{Normal, Distribution, Exp};
 
 use crate::game::context::GameContext;
@@ -41,11 +41,95 @@ const P_BP_COEF: f64 = 0.82863208;
 const P_FUMBLE_INTR: f64 = 0.04932479844415921;
 const P_FUMBLE_COEF: f64 = -0.08432772;
 
+/// # `RunResultRaw` struct
+///
+/// A `RunResultRaw` represents a result of a run play
+#[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize, Deserialize)]
+pub struct RunResultRaw {
+    yards_gained: i32,
+    play_duration: u32,
+    fumble: bool,
+    return_yards: i32,
+    out_of_bounds: bool,
+    touchdown: bool,
+    safety: bool
+}
+
+impl RunResultRaw {
+    pub fn validate(&self) -> Result<(), String> {
+        // Ensure play duration is not greater than 100
+        if self.play_duration > 100 {
+            return Err(
+                format!(
+                    "Play duration is not in range [0, 100]: {}",
+                    self.play_duration
+                )
+            )
+        }
+
+        // Ensure yards gained are in range [-100, 100]
+        if self.yards_gained.abs() > 100 {
+            return Err(
+                format!(
+                    "Yards gained is not in range [-100, 100]: {}",
+                    self.yards_gained
+                )
+            )
+        }
+
+        // Ensure return yards are in range [-100, 100]
+        if self.return_yards.abs() > 100 {
+            return Err(
+                format!(
+                    "Return yards is not in range [-100, 100]: {}",
+                    self.return_yards
+                )
+            )
+        }
+
+        // Ensure if there is no fumble, the return yards are zero
+        if !self.fumble && self.return_yards != 0 {
+            return Err(
+                format!(
+                    "Fumble did not occur but return yards were nonzero: {}",
+                    self.return_yards
+                )
+            )
+        }
+
+        // Ensure if there is a fumble, there is not also a safety
+        if self.fumble && self.safety {
+            return Err(
+                String::from("Cannot have both a fumble and a safety")
+            )
+        }
+
+        // Ensure if out of bounds, there is not also a touchdown or safety
+        if self.out_of_bounds && (self.touchdown || self.safety) {
+            return Err(
+                format!(
+                    "Cannot have both a rush out of bounds and a touchdown ({}) or safety ({})",
+                    self.touchdown, self.safety
+                )
+            )
+        }
+
+        // Ensure there is not both a safety and a touchdown
+        if self.touchdown && self.safety {
+            return Err(
+                String::from("Cannot have both a touchdown and a safety")
+            )
+        }
+        Ok(())
+    }
+}
+
 /// # `RunResult` struct
 ///
 /// A `RunResult` represents a result of a run play
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
-#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize)]
 pub struct RunResult {
     yards_gained: i32,
     play_duration: u32,
@@ -53,8 +137,43 @@ pub struct RunResult {
     return_yards: i32,
     out_of_bounds: bool,
     touchdown: bool,
-    safety: bool,
-    scramble: bool
+    safety: bool
+}
+
+impl TryFrom<RunResultRaw> for RunResult {
+    type Error = String;
+
+    fn try_from(item: RunResultRaw) -> Result<Self, Self::Error> {
+        // Validate the raw between play result
+        match item.validate() {
+            Ok(()) => (),
+            Err(error) => return Err(error),
+        };
+
+        // If valid, then convert
+        Ok(
+            RunResult{
+                yards_gained: item.yards_gained,
+                play_duration: item.play_duration,
+                fumble: item.fumble,
+                return_yards: item.return_yards,
+                out_of_bounds: item.out_of_bounds,
+                touchdown: item.touchdown,
+                safety: item.safety
+            }
+        )
+    }
+}
+
+impl<'de> Deserialize<'de> for RunResult {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Only deserialize if the conversion from raw succeeds
+        let raw = RunResultRaw::deserialize(deserializer)?;
+        RunResult::try_from(raw).map_err(serde::de::Error::custom)
+    }
 }
 
 impl Default for RunResult {
@@ -74,8 +193,7 @@ impl Default for RunResult {
             return_yards: 0,
             out_of_bounds: false,
             touchdown: false,
-            safety: false,
-            scramble: false
+            safety: false
         }
     }
 }
@@ -278,19 +396,200 @@ impl RunResult {
     pub fn safety(&self) -> bool {
         self.safety
     }
+}
 
-    /// Get a run result's scramble property
+/// # `RunResultBuilder` struct
+///
+/// A `RunResultBuilder` is a builder pattern implementation for the
+/// `RunResult` struct
+#[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize)]
+pub struct RunResultBuilder {
+    yards_gained: i32,
+    play_duration: u32,
+    fumble: bool,
+    return_yards: i32,
+    out_of_bounds: bool,
+    touchdown: bool,
+    safety: bool
+}
+
+impl Default for RunResultBuilder {
+    /// Default constructor for the RunResultBuilder struct
     ///
     /// ### Example
     /// ```
-    /// use fbsim_core::game::play::result::run::RunResult;
+    /// use fbsim_core::game::play::result::run::RunResultBuilder;
     /// 
-    /// let my_res = RunResult::new();
-    /// let scramble = my_res.scramble();
-    /// assert!(!scramble);
+    /// let my_result = RunResultBuilder::default();
     /// ```
-    pub fn scramble(&self) -> bool {
-        self.scramble
+    fn default() -> Self {
+        RunResultBuilder{
+            yards_gained: 0,
+            play_duration: 0,
+            fumble: false,
+            return_yards: 0,
+            out_of_bounds: false,
+            touchdown: false,
+            safety: false
+        }
+    }
+}
+
+impl RunResultBuilder {
+    /// Initialize a new RunResultBuilder
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::run::RunResultBuilder;
+    /// 
+    /// let my_builder = RunResultBuilder::new();
+    /// ```
+    pub fn new() -> RunResultBuilder {
+        RunResultBuilder::default()
+    }
+
+    /// Set the play_duration property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::run::RunResultBuilder;
+    /// 
+    /// let my_result = RunResultBuilder::new()
+    ///     .play_duration(10)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(my_result.play_duration() == 10);
+    /// ```
+    pub fn play_duration(mut self, play_duration: u32) -> Self {
+        self.play_duration = play_duration;
+        self
+    }
+
+    /// Set the yards_gained property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::run::RunResultBuilder;
+    /// 
+    /// let my_result = RunResultBuilder::new()
+    ///     .yards_gained(3)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(my_result.yards_gained() == 3);
+    /// ```
+    pub fn yards_gained(mut self, yards_gained: i32) -> Self {
+        self.yards_gained = yards_gained;
+        self
+    }
+
+    /// Set the return_yards property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::run::RunResultBuilder;
+    /// 
+    /// let my_result = RunResultBuilder::new()
+    ///     .fumble(true)
+    ///     .return_yards(12)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(my_result.return_yards() == 12);
+    /// ```
+    pub fn return_yards(mut self, return_yards: i32) -> Self {
+        self.return_yards = return_yards;
+        self
+    }
+
+    /// Set the fumble property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::run::RunResultBuilder;
+    /// 
+    /// let my_result = RunResultBuilder::new()
+    ///     .fumble(true)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(my_result.fumble());
+    /// ```
+    pub fn fumble(mut self, fumble: bool) -> Self {
+        self.fumble = fumble;
+        self
+    }
+
+    /// Set the out_of_bounds property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::run::RunResultBuilder;
+    /// 
+    /// let my_result = RunResultBuilder::new()
+    ///     .out_of_bounds(true)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(my_result.out_of_bounds());
+    /// ```
+    pub fn out_of_bounds(mut self, out_of_bounds: bool) -> Self {
+        self.out_of_bounds = out_of_bounds;
+        self
+    }
+
+    /// Set the touchdown property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::run::RunResultBuilder;
+    /// 
+    /// let my_result = RunResultBuilder::new()
+    ///     .touchdown(true)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(my_result.touchdown());
+    /// ```
+    pub fn touchdown(mut self, touchdown: bool) -> Self {
+        self.touchdown = touchdown;
+        self
+    }
+
+    /// Set the safety property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::run::RunResultBuilder;
+    /// 
+    /// let my_result = RunResultBuilder::new()
+    ///     .safety(true)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(my_result.safety());
+    /// ```
+    pub fn safety(mut self, safety: bool) -> Self {
+        self.safety = safety;
+        self
+    }
+
+    /// Build the RunResult
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::result::run::RunResultBuilder;
+    /// 
+    /// let my_result = RunResultBuilder::new()
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn build(self) -> Result<RunResult, String> {
+        let raw = RunResultRaw{
+            yards_gained: self.yards_gained,
+            play_duration: self.play_duration,
+            fumble: self.fumble,
+            return_yards: self.return_yards,
+            out_of_bounds: self.out_of_bounds,
+            touchdown: self.touchdown,
+            safety: self.safety
+        };
+        RunResult::try_from(raw)
     }
 }
 
@@ -442,8 +741,7 @@ impl PlayResultSimulator for RunResultSimulator {
             return_yards: return_yards,
             out_of_bounds: false,
             touchdown: touchdown,
-            safety: safety,
-            scramble: false
+            safety: safety
         };
         PlayTypeResult::Run(run_res)
     }

--- a/src/game/score/freq.rs
+++ b/src/game/score/freq.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 pub struct ScoreFrequencyLookup {
-    freq_lookup: HashMap<i32, i32>,
+    freq_lookup: HashMap<u32, u32>,
 }
 
 impl ScoreFrequencyLookup {
@@ -13,7 +13,7 @@ impl ScoreFrequencyLookup {
     }
 
     /// Insert a score into the lookup table
-    pub fn insert(&mut self, score: i32, freq: i32) {
+    pub fn insert(&mut self, score: u32, freq: u32) {
         self.freq_lookup.insert(
             score, freq
         );
@@ -87,18 +87,10 @@ impl ScoreFrequencyLookup {
     }
 
     /// Get the frequency of a score
-    pub fn frequency(&self, score: i32) -> Result<i32, String> {
-        if score < 0 {
-            return Err(
-                format!(
-                    "Score must be greater than 0: {}",
-                    score
-                )
-            )
-        }
+    pub fn frequency(&self, score: u32) -> Result<u32, String> {
         match self.freq_lookup.get(&score) {
             Some(freq) => return Ok(*freq),
-            None       => return Ok(1_i32),
+            None       => return Ok(1),
         }
     }
 }

--- a/src/team/coach.rs
+++ b/src/team/coach.rs
@@ -2,17 +2,110 @@
 use rocket_okapi::okapi::schemars;
 #[cfg(feature = "rocket_okapi")]
 use rocket_okapi::okapi::schemars::JsonSchema;
-use serde::{Serialize, Deserialize};
+use serde::{Serialize, Deserialize, Deserializer};
+
+/// # `FootballTeamCoachRaw` struct
+///
+/// A `FootballTeamCoachRaw` is a `FootballTeamCoach` before its properties
+/// have been validated
+#[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Default, Serialize, Deserialize)]
+pub struct FootballTeamCoachRaw {
+    risk_taking: u32,
+    run_pass: u32,
+    up_tempo: u32
+}
+
+impl FootballTeamCoachRaw {
+    pub fn validate(&self) -> Result<(), String> {
+        // Ensure each property is no greater than 100
+        if self.risk_taking > 100 {
+            return Err(
+                format!(
+                    "Risk taking attribute is out of range [0, 100]: {}",
+                    self.risk_taking
+                )
+            )
+        }
+        if self.run_pass > 100 {
+            return Err(
+                format!(
+                    "Run-pass attribute is out of range [0, 100]: {}",
+                    self.run_pass
+                )
+            )
+        }
+        if self.up_tempo > 100 {
+            return Err(
+                format!(
+                    "Up-tempo attribute is out of range [0, 100]: {}",
+                    self.up_tempo
+                )
+            )
+        }
+        Ok(())
+    }
+}
 
 /// # `FootballTeamCoach` struct
 ///
 /// A `FootballTeamCoach` represents a football team coach
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize)]
 pub struct FootballTeamCoach {
     risk_taking: u32,
     run_pass: u32,
     up_tempo: u32
+}
+
+impl TryFrom<FootballTeamCoachRaw> for FootballTeamCoach {
+    type Error = String;
+
+    fn try_from(item: FootballTeamCoachRaw) -> Result<Self, Self::Error> {
+        // Validate the raw coach
+        match item.validate() {
+            Ok(()) => (),
+            Err(error) => return Err(error),
+        };
+
+        // If valid, then convert
+        Ok(
+            FootballTeamCoach{
+                risk_taking: item.risk_taking,
+                run_pass: item.run_pass,
+                up_tempo: item.up_tempo
+            }
+        )
+    }
+}
+
+impl<'de> Deserialize<'de> for FootballTeamCoach {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Only deserialize if the conversion from raw succeeds
+        let raw = FootballTeamCoachRaw::deserialize(deserializer)?;
+        FootballTeamCoach::try_from(raw).map_err(serde::de::Error::custom)
+    }
+}
+
+impl Default for FootballTeamCoach {
+    /// Default constructor for the FootballTeamCoach class
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::coach::FootballTeamCoach;
+    /// 
+    /// let my_coach_builder = FootballTeamCoach::default();
+    /// ```
+    fn default() -> Self {
+        FootballTeamCoach{
+            risk_taking: 50_u32,
+            run_pass: 50_u32,
+            up_tempo: 50_u32
+        }
+    }
 }
 
 impl FootballTeamCoach {
@@ -26,40 +119,7 @@ impl FootballTeamCoach {
     /// let my_coach = FootballTeamCoach::new();
     /// ```
     pub fn new() -> FootballTeamCoach {
-        FootballTeamCoach{
-            risk_taking: 50_u32,
-            run_pass: 50_u32,
-            up_tempo: 50_u32
-        }
-    }
-
-    /// Constructor for the `FootballTeamCoach` struct in which each
-    /// property is given as an argument.
-    ///
-    /// ### Example
-    /// ```
-    /// use fbsim_core::team::coach::FootballTeamCoach;
-    ///
-    /// let my_coach = FootballTeamCoach::from_properties(0, 50, 100);
-    /// ```
-    pub fn from_properties(risk_taking: u32, run_pass: u32, up_tempo: u32) -> Result<FootballTeamCoach, String> {
-        // Ensure each skill level is in range
-        if risk_taking > 100_u32 {
-            return Err(format!("Risk taking not in range [0, 100]: {}", risk_taking))
-        }
-        if run_pass > 100_u32 {
-            return Err(format!("Run-pass not in range [0, 100]: {}", run_pass))
-        }
-        if up_tempo > 100_u32 {
-            return Err(format!("Up tempo not in range [0, 100]: {}", up_tempo))
-        }
-        Ok(
-            FootballTeamCoach{
-                risk_taking: risk_taking,
-                run_pass: run_pass,
-                up_tempo: up_tempo
-            }
-        )
+        FootballTeamCoach::default()
     }
 
     /// Get the coach's risk taking tendency
@@ -102,5 +162,122 @@ impl FootballTeamCoach {
     /// ```
     pub fn run_pass(&self) -> u32 {
         self.run_pass
+    }
+}
+
+/// # `FootballTeamCoachBuilder` struct
+///
+/// A `FootballTeamCoachBuilder` implements the builder pattern for the
+/// `FootballTeamCoach` struct
+#[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize)]
+pub struct FootballTeamCoachBuilder {
+    risk_taking: u32,
+    run_pass: u32,
+    up_tempo: u32
+}
+
+impl Default for FootballTeamCoachBuilder {
+    /// Default constructor for the FootballTeamCoachBuilder class
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::coach::FootballTeamCoachBuilder;
+    /// 
+    /// let my_coach_builder = FootballTeamCoachBuilder::default();
+    /// ```
+    fn default() -> Self {
+        FootballTeamCoachBuilder{
+            risk_taking: 50_u32,
+            run_pass: 50_u32,
+            up_tempo: 50_u32
+        }
+    }
+}
+
+impl FootballTeamCoachBuilder {
+    /// Initialize a new coach builder
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::coach::FootballTeamCoachBuilder;
+    ///
+    /// let mut my_coach_builder = FootballTeamCoachBuilder::new();
+    /// ```
+    pub fn new() -> FootballTeamCoachBuilder {
+        FootballTeamCoachBuilder::default()
+    }
+
+    /// Set the risk taking property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::coach::{FootballTeamCoach, FootballTeamCoachBuilder};
+    /// 
+    /// let my_coach = FootballTeamCoachBuilder::new()
+    ///     .risk_taking(60)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(my_coach.risk_taking() == 60);
+    /// ```
+    pub fn risk_taking(mut self, risk_taking: u32) -> Self {
+        self.risk_taking = risk_taking;
+        self
+    }
+
+    /// Set the run-pass property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::coach::{FootballTeamCoach, FootballTeamCoachBuilder};
+    /// 
+    /// let my_coach = FootballTeamCoachBuilder::new()
+    ///     .run_pass(60)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(my_coach.run_pass() == 60);
+    /// ```
+    pub fn run_pass(mut self, run_pass: u32) -> Self {
+        self.run_pass = run_pass;
+        self
+    }
+
+    /// Set the up-tempo property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::coach::{FootballTeamCoach, FootballTeamCoachBuilder};
+    /// 
+    /// let my_coach = FootballTeamCoachBuilder::new()
+    ///     .up_tempo(60)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(my_coach.up_tempo() == 60);
+    /// ```
+    pub fn up_tempo(mut self, up_tempo: u32) -> Self {
+        self.up_tempo = up_tempo;
+        self
+    }
+
+    /// Build the coach
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::coach::{FootballTeamCoach, FootballTeamCoachBuilder};
+    /// 
+    /// let my_coach = FootballTeamCoachBuilder::new()
+    ///     .risk_taking(40)
+    ///     .run_pass(50)
+    ///     .up_tempo(60)
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn build(self) -> Result<FootballTeamCoach, String> {
+        let raw = FootballTeamCoachRaw{
+            risk_taking: self.risk_taking,
+            run_pass: self.run_pass,
+            up_tempo: self.up_tempo
+        };
+        FootballTeamCoach::try_from(raw)
     }
 }


### PR DESCRIPTION
In this PR, I implement
- Variable sack yards lost
- Variable scramble yards based on differential between scrambling & rush defense
- Pass distance-based completion probability
- Raw validation & builder pattern implementations for core play-by-play structs (`*Result` and `GameContext`)

For reference, see:
- https://github.com/whatsacomputertho/fbsim-core/issues/37
- https://github.com/whatsacomputertho/fbsim-core/issues/38
- https://github.com/whatsacomputertho/fbsim-core/issues/39
- https://github.com/whatsacomputertho/fbsim-core/issues/49
