### PR TITLE
feat(advantage): add home field advantage and neutral site games

### DIFF
--- a/src/game/context.rs
+++ b/src/game/context.rs
@@ -37,6 +37,7 @@ pub struct GameContextRaw {
     last_play_punt: bool,
     next_play_extra_point: bool,
     next_play_kickoff: bool,
+    neutral_site: bool,
     end_of_half: bool,
     game_over: bool
 }
@@ -267,6 +268,7 @@ pub struct GameContext {
     last_play_punt: bool,
     next_play_extra_point: bool,
     next_play_kickoff: bool,
+    neutral_site: bool,
     end_of_half: bool,
     game_over: bool
 }
@@ -304,6 +306,7 @@ impl Default for GameContext {
             last_play_punt: false,
             next_play_extra_point: false,
             next_play_kickoff: true,
+            neutral_site: false,
             end_of_half: false,
             game_over: false
         }
@@ -345,6 +348,7 @@ impl TryFrom<GameContextRaw> for GameContext {
                 last_play_punt: item.last_play_punt,
                 next_play_extra_point: item.next_play_extra_point,
                 next_play_kickoff: item.next_play_kickoff,
+                neutral_site: item.neutral_site,
                 end_of_half: item.end_of_half,
                 game_over: item.game_over
             }
@@ -684,6 +688,20 @@ impl GameContext {
         self.next_play_extra_point
     }
 
+    /// Get the GameContext neutral_site property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::context::GameContext;
+    /// 
+    /// let my_context = GameContext::new();
+    /// let neutral_site = my_context.neutral_site();
+    /// assert!(!neutral_site);
+    /// ```
+    pub fn neutral_site(&self) -> bool {
+        self.neutral_site
+    }
+
     /// Borrow the GameContext end_of_half property
     ///
     /// ### Example
@@ -769,6 +787,34 @@ impl GameContext {
                 )
             )
         )
+    }
+
+    /// Determine whether to apply home field advantage to offense skill levels
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::context::GameContext;
+    /// 
+    /// let my_context = GameContext::new();
+    /// let home_field_advantage = my_context.offense_advantage();
+    /// assert!(home_field_advantage);
+    /// ```
+    pub fn offense_advantage(&self) -> bool {
+        self.home_possession && !self.neutral_site
+    }
+
+    /// Determine whether to apply home field advantage to defense skill levels
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::context::GameContext;
+    /// 
+    /// let my_context = GameContext::new();
+    /// let home_field_advantage = my_context.defense_advantage();
+    /// assert!(!home_field_advantage);
+    /// ```
+    pub fn defense_advantage(&self) -> bool {
+        !(self.home_possession || self.neutral_site)
     }
 
     /// Get the yards remaining until the defense's goal line
@@ -1419,6 +1465,7 @@ impl GameContext {
             last_play_punt: result.punt(),
             next_play_extra_point,
             next_play_kickoff: result.next_play_kickoff() || (end_of_half && !next_play_extra_point),
+            neutral_site: self.neutral_site,
             end_of_half,
             game_over: self.next_game_over(&update_opts)
         };
@@ -1486,6 +1533,7 @@ pub struct GameContextBuilder {
     last_play_punt: bool,
     next_play_extra_point: bool,
     next_play_kickoff: bool,
+    neutral_site: bool,
     end_of_half: bool,
     game_over: bool
 }
@@ -1523,6 +1571,7 @@ impl Default for GameContextBuilder {
             last_play_punt: false,
             next_play_extra_point: false,
             next_play_kickoff: true,
+            neutral_site: false,
             end_of_half: false,
             game_over: false
         }
@@ -1919,6 +1968,23 @@ impl GameContextBuilder {
         self
     }
     
+    /// Set the neutral site property
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::context::{GameContext, GameContextBuilder};
+    /// 
+    /// let my_context = GameContextBuilder::new()
+    ///     .neutral_site(true)
+    ///     .build()
+    ///     .unwrap();
+    /// assert!(my_context.neutral_site());
+    /// ```
+    pub fn neutral_site(mut self, neutral_site: bool) -> Self {
+        self.neutral_site = neutral_site;
+        self
+    }
+    
     /// Set the end of half property
     ///
     /// ### Example
@@ -2012,6 +2078,7 @@ impl GameContextBuilder {
             last_play_punt: self.last_play_punt,
             next_play_extra_point: self.next_play_extra_point,
             next_play_kickoff: self.next_play_kickoff,
+            neutral_site: self.neutral_site,
             end_of_half: self.end_of_half,
             game_over: self.game_over
         };

--- a/src/game/play/result/fieldgoal.rs
+++ b/src/game/play/result/fieldgoal.rs
@@ -707,8 +707,15 @@ impl PlayResultSimulator for FieldGoalResultSimulator {
     /// ```
     fn sim(&self, offense: &impl PlaySimulatable, defense: &impl PlaySimulatable, context: &GameContext, rng: &mut impl Rng) -> PlayTypeResult {
         // Calculate normalized skill levels and skill diffs
-        let norm_diff_blocking: f64 = 0.5_f64 + ((offense.offense().blocking() as f64 - defense.defense().blitzing() as f64) / 200_f64);
-        let norm_kicking: f64 = offense.offense().field_goals() as f64 / 100_f64;
+        let offense_advantage: bool = context.offense_advantage();
+        let defense_advantage: bool = context.defense_advantage();
+        let norm_diff_blocking: f64 = 0.5_f64 + (
+            (
+                offense.offense().blocking_advantage(offense_advantage) as f64 -
+                defense.defense().blitzing_advantage(defense_advantage) as f64
+            ) / 200_f64
+        );
+        let norm_kicking: f64 = offense.offense().field_goals_advantage(offense_advantage) as f64 / 100_f64;
         let td_yards: i32 = context.yards_to_touchdown();
         let safety_yards: i32 = context.yards_to_safety();
 

--- a/src/game/play/result/kickoff.rs
+++ b/src/game/play/result/kickoff.rs
@@ -889,8 +889,15 @@ impl PlayResultSimulator for KickoffResultSimulator {
     /// ```
     fn sim(&self, offense: &impl PlaySimulatable, defense: &impl PlaySimulatable, context: &GameContext, rng: &mut impl Rng) -> PlayTypeResult {
         // Calculate normalized skill diffs & skill levels
-        let norm_kicking: f64 = offense.offense().kickoffs() as f64 / 100_f64;
-        let norm_diff_returning: f64 = 0.5_f64 + ((defense.defense().kick_returning() as f64 - offense.offense().kick_return_defense() as f64) / 200_f64);
+        let offense_advantage: bool = context.offense_advantage();
+        let defense_advantage: bool = context.defense_advantage();
+        let norm_kicking: f64 = offense.offense().kickoffs_advantage(offense_advantage) as f64 / 100_f64;
+        let norm_diff_returning: f64 = 0.5_f64 + (
+            (
+                defense.defense().kick_returning_advantage(defense_advantage) as f64 -
+                offense.offense().kick_return_defense_advantage(offense_advantage) as f64
+            ) / 200_f64
+        );
         let td_yards: i32 = context.yards_to_touchdown();
         let safety_yards: i32 = context.yards_to_safety();
         let play_context = PlayContext::from(context);

--- a/src/game/play/result/pass.rs
+++ b/src/game/play/result/pass.rs
@@ -1291,11 +1291,38 @@ impl PlayResultSimulator for PassResultSimulator {
     /// ```
     fn sim(&self, offense: &impl PlaySimulatable, defense: &impl PlaySimulatable, context: &GameContext, rng: &mut impl Rng) -> PlayTypeResult {
         // Derive the normalized skill differentials for each team
-        let norm_diff_blocking: f64 = 0.5_f64 + ((offense.offense().blocking() as f64 - defense.defense().blitzing() as f64) / 200_f64);
-        let norm_diff_passing: f64 = 0.5_f64 + ((offense.offense().passing() as f64 - defense.defense().pass_defense() as f64) / 200_f64);
-        let norm_diff_receiving: f64 = 0.5_f64 + ((offense.offense().receiving() as f64 - defense.defense().coverage() as f64) / 200_f64);
-        let norm_diff_turnovers: f64 = 0.5_f64 + ((offense.offense().turnovers() as f64 - defense.defense().turnovers() as f64) / 200_f64);
-        let norm_diff_scrambling: f64 = 0.5_f64 + ((offense.offense().scrambling() as f64 - defense.defense().rush_defense() as f64) / 200_f64);
+        let offense_advantage: bool = context.offense_advantage();
+        let defense_advantage: bool = context.defense_advantage();
+        let norm_diff_blocking: f64 = 0.5_f64 + (
+            (
+                offense.offense().blocking_advantage(offense_advantage) as f64 -
+                defense.defense().blitzing_advantage(defense_advantage) as f64
+            ) / 200_f64
+        );
+        let norm_diff_passing: f64 = 0.5_f64 + (
+            (
+                offense.offense().passing_advantage(offense_advantage) as f64 -
+                defense.defense().pass_defense_advantage(defense_advantage) as f64
+            ) / 200_f64
+        );
+        let norm_diff_receiving: f64 = 0.5_f64 + (
+            (
+                offense.offense().receiving_advantage(offense_advantage) as f64 -
+                defense.defense().coverage_advantage(defense_advantage) as f64
+            ) / 200_f64
+        );
+        let norm_diff_turnovers: f64 = 0.5_f64 + (
+            (
+                offense.offense().turnovers_advantage(offense_advantage) as f64 -
+                defense.defense().turnovers_advantage(defense_advantage) as f64
+            ) / 200_f64
+        );
+        let norm_diff_scrambling: f64 = 0.5_f64 + (
+            (
+                offense.offense().scrambling_advantage(offense_advantage) as f64 -
+                defense.defense().rush_defense_advantage(defense_advantage) as f64
+            ) / 200_f64
+        );
         let norm_scrambling: f64 = offense.offense().scrambling() as f64 / 100_f64;
         let td_yards = context.yards_to_touchdown();
         let yard_line = u32::try_from(td_yards).unwrap_or_default();

--- a/src/game/play/result/punt.rs
+++ b/src/game/play/result/punt.rs
@@ -1009,9 +1009,21 @@ impl PlayResultSimulator for PuntResultSimulator {
     /// ```
     fn sim(&self, offense: &impl PlaySimulatable, defense: &impl PlaySimulatable, context: &GameContext, rng: &mut impl Rng) -> PlayTypeResult {
         // Calculate normalized skill levels and skill diffs
-        let norm_diff_blocking: f64 = 0.5_f64 + ((offense.offense().blocking() as f64 - defense.defense().blitzing() as f64) / 200_f64);
-        let norm_diff_returning: f64 = 0.5_f64 + ((defense.defense().kick_returning() as f64 - offense.offense().kick_return_defense() as f64) / 200_f64);
-        let norm_punting: f64 = offense.offense().punting() as f64 / 100_f64;
+        let offense_advantage: bool = context.offense_advantage();
+        let defense_advantage: bool = context.defense_advantage();
+        let norm_diff_blocking: f64 = 0.5_f64 + (
+            (
+                offense.offense().blocking_advantage(offense_advantage) as f64 -
+                defense.defense().blitzing_advantage(defense_advantage) as f64
+            ) / 200_f64
+        );
+        let norm_diff_returning: f64 = 0.5_f64 + (
+            (
+                defense.defense().kick_returning_advantage(defense_advantage) as f64 -
+                offense.offense().kick_return_defense_advantage(offense_advantage) as f64
+            ) / 200_f64
+        );
+        let norm_punting: f64 = offense.offense().punting_advantage(offense_advantage) as f64 / 100_f64;
         let td_yards: i32 = context.yards_to_touchdown();
         
         // Generate whether the punt was blocked

--- a/src/game/play/result/run.rs
+++ b/src/game/play/result/run.rs
@@ -736,8 +736,20 @@ impl PlayResultSimulator for RunResultSimulator {
     /// ```
     fn sim(&self, offense: &impl PlaySimulatable, defense: &impl PlaySimulatable, context: &GameContext, rng: &mut impl Rng) -> PlayTypeResult {
         // Derive the normalized skill differentials for each team
-        let norm_diff_rushing: f64 = 0.5_f64 + ((offense.offense().rushing() as f64 - defense.defense().rush_defense() as f64) / 200_f64);
-        let norm_diff_turnovers: f64 = 0.5_f64 + ((offense.offense().turnovers() as f64 - defense.defense().turnovers() as f64) / 200_f64);
+        let offense_advantage: bool = context.offense_advantage();
+        let defense_advantage: bool = context.defense_advantage();
+        let norm_diff_rushing: f64 = 0.5_f64 + (
+            (
+                offense.offense().rushing_advantage(offense_advantage) as f64 -
+                defense.defense().rush_defense_advantage(defense_advantage) as f64
+            ) / 200_f64
+        );
+        let norm_diff_turnovers: f64 = 0.5_f64 + (
+            (
+                offense.offense().turnovers_advantage(offense_advantage) as f64 -
+                defense.defense().turnovers_advantage(defense_advantage) as f64
+            ) / 200_f64
+        );
         let td_yards = context.yards_to_touchdown();
         let safety_yards = context.yards_to_safety();
 

--- a/src/team/defense.rs
+++ b/src/team/defense.rs
@@ -5,6 +5,8 @@ use rocket_okapi::okapi::schemars;
 use rocket_okapi::okapi::schemars::JsonSchema;
 use serde::{Serialize, Deserialize, Deserializer};
 
+const DEFENSE_ADVANTAGE: u32 = 3_u32;
+
 /// # `FootballTeamDefenseRaw` struct
 ///
 /// A `FootballTeamDefenseRaw` is a `FootballTeamDefense` before its properties
@@ -214,6 +216,25 @@ impl FootballTeamDefense {
         self.rush_defense
     }
 
+    /// Get the defense's rush defense skill level with home field advantage
+    /// applied
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::defense::FootballTeamDefense;
+    /// 
+    /// let my_defense = FootballTeamDefense::new();
+    /// let rush_defense = my_defense.rush_defense_advantage(true);
+    /// assert!(rush_defense == 53_u32);
+    /// ```
+    pub fn rush_defense_advantage(&self, defense_advantage: bool) -> u32 {
+        if defense_advantage {
+            100_u32.min(self.rush_defense + DEFENSE_ADVANTAGE)
+        } else {
+            self.rush_defense
+        }
+    }
+
     /// Get the defense's pass defense skill level
     ///
     /// ### Example
@@ -226,6 +247,25 @@ impl FootballTeamDefense {
     /// ```
     pub fn pass_defense(&self) -> u32 {
         self.pass_defense
+    }
+
+    /// Get the defense's pass defense skill level with home field advantage
+    /// applied
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::defense::FootballTeamDefense;
+    /// 
+    /// let my_defense = FootballTeamDefense::new();
+    /// let pass_defense = my_defense.pass_defense_advantage(true);
+    /// assert!(pass_defense == 53_u32);
+    /// ```
+    pub fn pass_defense_advantage(&self, defense_advantage: bool) -> u32 {
+        if defense_advantage {
+            100_u32.min(self.pass_defense + DEFENSE_ADVANTAGE)
+        } else {
+            self.pass_defense
+        }
     }
 
     /// Get the defense's coverage skill level
@@ -242,6 +282,25 @@ impl FootballTeamDefense {
         self.coverage
     }
 
+    /// Get the defense's coverage skill level with home field advantage
+    /// applied
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::defense::FootballTeamDefense;
+    /// 
+    /// let my_defense = FootballTeamDefense::new();
+    /// let coverage = my_defense.coverage_advantage(true);
+    /// assert!(coverage == 53_u32);
+    /// ```
+    pub fn coverage_advantage(&self, defense_advantage: bool) -> u32 {
+        if defense_advantage {
+            100_u32.min(self.coverage + DEFENSE_ADVANTAGE)
+        } else {
+            self.coverage
+        }
+    }
+
     /// Get the defense's blitzing skill level
     ///
     /// ### Example
@@ -254,6 +313,25 @@ impl FootballTeamDefense {
     /// ```
     pub fn blitzing(&self) -> u32 {
         self.blitzing
+    }
+
+    /// Get the defense's blitzing skill level with home field advantage
+    /// applied
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::defense::FootballTeamDefense;
+    /// 
+    /// let my_defense = FootballTeamDefense::new();
+    /// let blitzing = my_defense.blitzing_advantage(true);
+    /// assert!(blitzing == 53_u32);
+    /// ```
+    pub fn blitzing_advantage(&self, defense_advantage: bool) -> u32 {
+        if defense_advantage {
+            100_u32.min(self.blitzing + DEFENSE_ADVANTAGE)
+        } else {
+            self.blitzing
+        }
     }
 
     /// Get the defense's turnovers skill level
@@ -270,6 +348,25 @@ impl FootballTeamDefense {
         self.turnovers
     }
 
+    /// Get the defense's turnovers skill level with home field advantage
+    /// applied
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::defense::FootballTeamDefense;
+    /// 
+    /// let my_defense = FootballTeamDefense::new();
+    /// let turnovers = my_defense.turnovers_advantage(true);
+    /// assert!(turnovers == 53_u32);
+    /// ```
+    pub fn turnovers_advantage(&self, defense_advantage: bool) -> u32 {
+        if defense_advantage {
+            100_u32.min(self.turnovers + DEFENSE_ADVANTAGE)
+        } else {
+            self.turnovers
+        }
+    }
+
     /// Get the defense's kick returning skill level
     ///
     /// ### Example
@@ -282,6 +379,25 @@ impl FootballTeamDefense {
     /// ```
     pub fn kick_returning(&self) -> u32 {
         self.kick_returning
+    }
+
+    /// Get the defense's kick returning skill level with home field advantage
+    /// applied
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::defense::FootballTeamDefense;
+    /// 
+    /// let my_defense = FootballTeamDefense::new();
+    /// let kick_returning = my_defense.kick_returning_advantage(true);
+    /// assert!(kick_returning == 53_u32);
+    /// ```
+    pub fn kick_returning_advantage(&self, defense_advantage: bool) -> u32 {
+        if defense_advantage {
+            100_u32.min(self.kick_returning + DEFENSE_ADVANTAGE)
+        } else {
+            self.kick_returning
+        }
     }
 }
 

--- a/src/team/offense.rs
+++ b/src/team/offense.rs
@@ -5,6 +5,8 @@ use rocket_okapi::okapi::schemars;
 use rocket_okapi::okapi::schemars::JsonSchema;
 use serde::{Serialize, Deserialize, Deserializer};
 
+const OFFENSE_ADVANTAGE: u32 = 3_u32;
+
 /// # `FootballTeamOffenseRaw` struct
 ///
 /// A `FootballTeamOffenseRaw` is a `FootballTeamOffense` before its properties
@@ -268,6 +270,24 @@ impl FootballTeamOffense {
         self.rushing
     }
 
+    /// Get the offense's rushing skill level with home-field advantage applied
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::offense::FootballTeamOffense;
+    /// 
+    /// let my_offense = FootballTeamOffense::new();
+    /// let rushing = my_offense.rushing_advantage(true);
+    /// assert!(rushing == 53_u32);
+    /// ```
+    pub fn rushing_advantage(&self, offense_advantage: bool) -> u32 {
+        if offense_advantage {
+            100_u32.min(self.rushing + OFFENSE_ADVANTAGE)
+        } else {
+            self.rushing
+        }
+    }
+
     /// Get the offense's passing skill level
     ///
     /// ### Example
@@ -280,6 +300,24 @@ impl FootballTeamOffense {
     /// ```
     pub fn passing(&self) -> u32 {
         self.passing
+    }
+
+    /// Get the offense's passing skill level with home-field advantage applied
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::offense::FootballTeamOffense;
+    /// 
+    /// let my_offense = FootballTeamOffense::new();
+    /// let passing = my_offense.passing_advantage(true);
+    /// assert!(passing == 53_u32);
+    /// ```
+    pub fn passing_advantage(&self, offense_advantage: bool) -> u32 {
+        if offense_advantage {
+            100_u32.min(self.passing + OFFENSE_ADVANTAGE)
+        } else {
+            self.passing
+        }
     }
 
     /// Get the offense's receiving skill level
@@ -296,6 +334,24 @@ impl FootballTeamOffense {
         self.receiving
     }
 
+    /// Get the offense's receiving skill level with home-field advantage applied
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::offense::FootballTeamOffense;
+    /// 
+    /// let my_offense = FootballTeamOffense::new();
+    /// let receiving = my_offense.receiving_advantage(true);
+    /// assert!(receiving == 53_u32);
+    /// ```
+    pub fn receiving_advantage(&self, offense_advantage: bool) -> u32 {
+        if offense_advantage {
+            100_u32.min(self.receiving + OFFENSE_ADVANTAGE)
+        } else {
+            self.receiving
+        }
+    }
+
     /// Get the offense's scrambling skill level
     ///
     /// ### Example
@@ -308,6 +364,24 @@ impl FootballTeamOffense {
     /// ```
     pub fn scrambling(&self) -> u32 {
         self.scrambling
+    }
+
+    /// Get the offense's scrambling skill level with home-field advantage applied
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::offense::FootballTeamOffense;
+    /// 
+    /// let my_offense = FootballTeamOffense::new();
+    /// let scrambling = my_offense.scrambling_advantage(true);
+    /// assert!(scrambling == 53_u32);
+    /// ```
+    pub fn scrambling_advantage(&self, offense_advantage: bool) -> u32 {
+        if offense_advantage {
+            100_u32.min(self.scrambling + OFFENSE_ADVANTAGE)
+        } else {
+            self.scrambling
+        }
     }
 
     /// Get the offense's blocking skill level
@@ -324,6 +398,24 @@ impl FootballTeamOffense {
         self.blocking
     }
 
+    /// Get the offense's blocking skill level with home-field advantage applied
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::offense::FootballTeamOffense;
+    /// 
+    /// let my_offense = FootballTeamOffense::new();
+    /// let blocking = my_offense.blocking_advantage(true);
+    /// assert!(blocking == 53_u32);
+    /// ```
+    pub fn blocking_advantage(&self, offense_advantage: bool) -> u32 {
+        if offense_advantage {
+            100_u32.min(self.blocking + OFFENSE_ADVANTAGE)
+        } else {
+            self.blocking
+        }
+    }
+
     /// Get the offense's turnovers skill level
     ///
     /// ### Example
@@ -336,6 +428,24 @@ impl FootballTeamOffense {
     /// ```
     pub fn turnovers(&self) -> u32 {
         self.turnovers
+    }
+
+    /// Get the offense's turnovers skill level with home-field advantage applied
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::offense::FootballTeamOffense;
+    /// 
+    /// let my_offense = FootballTeamOffense::new();
+    /// let turnovers = my_offense.turnovers_advantage(true);
+    /// assert!(turnovers == 53_u32);
+    /// ```
+    pub fn turnovers_advantage(&self, offense_advantage: bool) -> u32 {
+        if offense_advantage {
+            100_u32.min(self.turnovers + OFFENSE_ADVANTAGE)
+        } else {
+            self.turnovers
+        }
     }
 
     /// Get the offense's field goal kicking skill level
@@ -352,6 +462,25 @@ impl FootballTeamOffense {
         self.field_goals
     }
 
+    /// Get the offense's field goal kicking skill level with home-field
+    /// advantage applied
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::offense::FootballTeamOffense;
+    /// 
+    /// let my_offense = FootballTeamOffense::new();
+    /// let field_goals = my_offense.field_goals_advantage(true);
+    /// assert!(field_goals == 53_u32);
+    /// ```
+    pub fn field_goals_advantage(&self, offense_advantage: bool) -> u32 {
+        if offense_advantage {
+            100_u32.min(self.field_goals + OFFENSE_ADVANTAGE)
+        } else {
+            self.field_goals
+        }
+    }
+
     /// Get the offense's punting skill level
     ///
     /// ### Example
@@ -364,6 +493,24 @@ impl FootballTeamOffense {
     /// ```
     pub fn punting(&self) -> u32 {
         self.punting
+    }
+
+    /// Get the offense's punting skill level with home-field advantage applied
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::offense::FootballTeamOffense;
+    /// 
+    /// let my_offense = FootballTeamOffense::new();
+    /// let punting = my_offense.punting_advantage(true);
+    /// assert!(punting == 53_u32);
+    /// ```
+    pub fn punting_advantage(&self, offense_advantage: bool) -> u32 {
+        if offense_advantage {
+            100_u32.min(self.punting + OFFENSE_ADVANTAGE)
+        } else {
+            self.punting
+        }
     }
 
     /// Get the offense's kickoffs skill level
@@ -380,6 +527,25 @@ impl FootballTeamOffense {
         self.kickoffs
     }
 
+    /// Get the offense's kickoffs skill level with home-field advantage
+    /// applied
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::offense::FootballTeamOffense;
+    /// 
+    /// let my_offense = FootballTeamOffense::new();
+    /// let kickoffs = my_offense.kickoffs_advantage(true);
+    /// assert!(kickoffs == 53_u32);
+    /// ```
+    pub fn kickoffs_advantage(&self, offense_advantage: bool) -> u32 {
+        if offense_advantage {
+            100_u32.min(self.kickoffs + OFFENSE_ADVANTAGE)
+        } else {
+            self.kickoffs
+        }
+    }
+
     /// Get the offense's kick return defense skill level
     ///
     /// ### Example
@@ -392,6 +558,25 @@ impl FootballTeamOffense {
     /// ```
     pub fn kick_return_defense(&self) -> u32 {
         self.kick_return_defense
+    }
+
+    /// Get the offense's kick return defense skill level with home-field
+    /// advantage applied
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::offense::FootballTeamOffense;
+    /// 
+    /// let my_offense = FootballTeamOffense::new();
+    /// let kick_return_defense = my_offense.kick_return_defense_advantage(true);
+    /// assert!(kick_return_defense == 53_u32);
+    /// ```
+    pub fn kick_return_defense_advantage(&self, offense_advantage: bool) -> u32 {
+        if offense_advantage {
+            100_u32.min(self.kick_return_defense + OFFENSE_ADVANTAGE)
+        } else {
+            self.kick_return_defense
+        }
     }
 }
 


### PR DESCRIPTION
In this PR I implement home field advantage and neutral site games in the play-by-play model.

For reference, see:
- https://github.com/whatsacomputertho/fbsim-core/issues/45