### PR TITLE
feat(league): ability to simulate league matchups play-by-play

### DIFF
--- a/src/game/play.rs
+++ b/src/game/play.rs
@@ -19,7 +19,7 @@ use crate::game::play::result::kickoff::KickoffResultSimulator;
 use crate::game::play::result::punt::PuntResultSimulator;
 use crate::game::play::result::pass::PassResultSimulator;
 use crate::game::play::result::run::RunResultSimulator;
-use crate::game::stat::{PassingStats, RushingStats, ReceivingStats};
+use crate::game::stat::{PassingStats, RushingStats, ReceivingStats, OffensiveStats};
 use crate::team::FootballTeam;
 use crate::team::coach::FootballTeamCoach;
 use crate::team::defense::FootballTeamDefense;
@@ -1134,6 +1134,40 @@ impl Game {
             }
         }
         stats
+    }
+
+    /// Get the offensive stats for the home team
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::Game;
+    ///
+    /// let game = Game::new();
+    /// let home_stats = game.home_stats();
+    /// ```
+    pub fn home_stats(&self) -> OffensiveStats {
+        OffensiveStats::from_properties(
+            self.passing_stats(true),
+            self.rushing_stats(true),
+            self.receiving_stats(true)
+        )
+    }
+
+    /// Get the offensive stats for the away team
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::play::Game;
+    ///
+    /// let game = Game::new();
+    /// let away_stats = game.away_stats();
+    /// ```
+    pub fn away_stats(&self) -> OffensiveStats {
+        OffensiveStats::from_properties(
+            self.passing_stats(false),
+            self.rushing_stats(false),
+            self.receiving_stats(false)
+        )
     }
 }
 

--- a/src/game/stat.rs
+++ b/src/game/stat.rs
@@ -580,3 +580,159 @@ impl std::fmt::Display for ReceivingStats {
         f.write_str(&receiving_str)
     }
 }
+
+/// # `ReceivingStats` struct
+///
+/// A `ReceivingStats` represents aggregated receiving statistics
+#[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Default, Serialize, Deserialize)]
+pub struct OffensiveStats {
+    passing: PassingStats,
+    rushing: RushingStats,
+    receiving: ReceivingStats
+}
+
+impl OffensiveStats {
+    /// Initialize a new OffensiveStats instance
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::stat::OffensiveStats;
+    /// 
+    /// let my_stats = OffensiveStats::new();
+    /// ```
+    pub fn new() -> OffensiveStats {
+        OffensiveStats {
+            passing: PassingStats::new(),
+            rushing: RushingStats::new(),
+            receiving: ReceivingStats::new()
+        }
+    }
+
+    /// Initialize a new OffensiveStats instance given each stat category
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::stat::{
+    ///     RushingStats,
+    ///     PassingStats,
+    ///     ReceivingStats,
+    ///     OffensiveStats
+    /// };
+    /// 
+    /// let my_stats = OffensiveStats::from_properties(
+    ///     PassingStats::new(),
+    ///     RushingStats::new(),
+    ///     ReceivingStats::new()
+    /// );
+    /// ```
+    pub fn from_properties(passing: PassingStats, rushing: RushingStats, receiving: ReceivingStats) -> OffensiveStats {
+        OffensiveStats {
+            passing,
+            rushing,
+            receiving
+        }
+    }
+
+    /// Borrow the passing stats
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::stat::OffensiveStats;
+    /// 
+    /// let my_stats = OffensiveStats::new();
+    /// let my_passing = my_stats.passing();
+    /// assert!(my_passing.completions() == 0);
+    /// ```
+    pub fn passing(&self) -> &PassingStats {
+        &self.passing
+    }
+
+    /// Mutably borrow the passing stats
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::stat::OffensiveStats;
+    /// 
+    /// let mut my_stats = OffensiveStats::new();
+    /// let my_passing = my_stats.passing_mut();
+    /// ```
+    pub fn passing_mut(&mut self) -> &mut PassingStats {
+        &mut self.passing
+    }
+
+    /// Borrow the rushing stats
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::stat::OffensiveStats;
+    /// 
+    /// let my_stats = OffensiveStats::new();
+    /// let my_rushing = my_stats.rushing();
+    /// assert!(my_rushing.rushes() == 0);
+    /// ```
+    pub fn rushing(&self) -> &RushingStats {
+        &self.rushing
+    }
+
+    /// Mutably borrow the rushing stats
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::stat::OffensiveStats;
+    /// 
+    /// let mut my_stats = OffensiveStats::new();
+    /// let my_rushing = my_stats.rushing_mut();
+    /// ```
+    pub fn rushing_mut(&mut self) -> &mut RushingStats {
+        &mut self.rushing
+    }
+
+    /// Borrow the receiving stats
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::stat::OffensiveStats;
+    /// 
+    /// let my_stats = OffensiveStats::new();
+    /// let my_receiving = my_stats.receiving();
+    /// assert!(my_receiving.targets() == 0);
+    /// ```
+    pub fn receiving(&self) -> &ReceivingStats {
+        &self.receiving
+    }
+
+    /// Mutably borrow the receiving stats
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::stat::OffensiveStats;
+    /// 
+    /// let mut my_stats = OffensiveStats::new();
+    /// let my_receiving = my_stats.receiving_mut();
+    /// ```
+    pub fn receiving_mut(&mut self) -> &mut ReceivingStats {
+        &mut self.receiving
+    }
+}
+
+impl std::fmt::Display for OffensiveStats {
+    /// Display offensive stats as a human readable string
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::game::stat::OffensiveStats;
+    /// 
+    /// let my_stats = OffensiveStats::new();
+    /// println!("{}", my_stats);
+    /// ```
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let stat_str = format!(
+            "Passing: {}\nRushing: {}\nReceiving: {}",
+            &self.passing,
+            &self.rushing,
+            &self.receiving
+        );
+        f.write_str(&stat_str)
+    }
+}

--- a/src/league/season/matchup.rs
+++ b/src/league/season/matchup.rs
@@ -8,6 +8,7 @@ use serde::{Serialize, Deserialize};
 
 use crate::game::context::{GameContext, GameContextBuilder};
 use crate::game::play::Game;
+use crate::game::stat::OffensiveStats;
 use crate::game::matchup::FootballMatchupResult;
 use crate::league::matchup::LeagueTeamRecord;
 
@@ -20,7 +21,9 @@ pub struct LeagueSeasonMatchup {
     home_team: usize,
     away_team: usize,
     context: GameContext,
-    game: Game
+    game: Option<Game>,
+    home_stats: Option<OffensiveStats>,
+    away_stats: Option<OffensiveStats>
 }
 
 impl LeagueSeasonMatchup {
@@ -51,7 +54,9 @@ impl LeagueSeasonMatchup {
             home_team,
             away_team,
             context,
-            game: Game::new()
+            game: None,
+            home_stats: None,
+            away_stats: None
         }
     }
 
@@ -121,7 +126,7 @@ impl LeagueSeasonMatchup {
     /// let my_matchup = LeagueSeasonMatchup::new(0, 1, "HOME", "AWAY", &mut rng);
     /// let game = my_matchup.game();
     /// ```
-    pub fn game(&self) -> &Game {
+    pub fn game(&self) -> &Option<Game> {
         &self.game
     }
 
@@ -135,8 +140,78 @@ impl LeagueSeasonMatchup {
     /// let mut my_matchup = LeagueSeasonMatchup::new(0, 1, "HOME", "AWAY", &mut rng);
     /// let game = my_matchup.game_mut();
     /// ```
-    pub fn game_mut(&mut self) -> &mut Game {
+    pub fn game_mut(&mut self) -> &mut Option<Game> {
         &mut self.game
+    }
+
+    /// Take ownership of the matchup's Game
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::matchup::LeagueSeasonMatchup;
+    ///
+    /// let mut rng = rand::thread_rng();
+    /// let mut my_matchup = LeagueSeasonMatchup::new(0, 1, "HOME", "AWAY", &mut rng);
+    /// let game = my_matchup.take_game();
+    /// ```
+    pub fn take_game(&mut self) -> Option<Game> {
+        self.game.take()
+    }
+
+    /// Borrow the matchup's home stats
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::matchup::LeagueSeasonMatchup;
+    ///
+    /// let mut rng = rand::thread_rng();
+    /// let my_matchup = LeagueSeasonMatchup::new(0, 1, "HOME", "AWAY", &mut rng);
+    /// let home_stats = my_matchup.home_stats();
+    /// ```
+    pub fn home_stats(&self) -> &Option<OffensiveStats> {
+        &self.home_stats
+    }
+
+    /// Mutably borrow the matchup's home stats
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::matchup::LeagueSeasonMatchup;
+    ///
+    /// let mut rng = rand::thread_rng();
+    /// let mut my_matchup = LeagueSeasonMatchup::new(0, 1, "HOME", "AWAY", &mut rng);
+    /// let home_stats = my_matchup.home_stats_mut();
+    /// ```
+    pub fn home_stats_mut(&mut self) -> &mut Option<OffensiveStats> {
+        &mut self.home_stats
+    }
+
+    /// Borrow the matchup's away stats
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::matchup::LeagueSeasonMatchup;
+    ///
+    /// let mut rng = rand::thread_rng();
+    /// let my_matchup = LeagueSeasonMatchup::new(0, 1, "HOME", "AWAY", &mut rng);
+    /// let away_stats = my_matchup.away_stats();
+    /// ```
+    pub fn away_stats(&self) -> &Option<OffensiveStats> {
+        &self.away_stats
+    }
+
+    /// Mutably borrow the matchup's away stats
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::matchup::LeagueSeasonMatchup;
+    ///
+    /// let mut rng = rand::thread_rng();
+    /// let mut my_matchup = LeagueSeasonMatchup::new(0, 1, "HOME", "AWAY", &mut rng);
+    /// let away_stats = my_matchup.away_stats_mut();
+    /// ```
+    pub fn away_stats_mut(&mut self) -> &mut Option<OffensiveStats> {
+        &mut self.away_stats
     }
 
     /// Determine whether the given team participated in the matchup


### PR DESCRIPTION
In this PR, I implement the ability to simulate a single play of a league matchup. The league season matchup struct stores an `Option<Game>` now which is treated as a scratchpad for storing game progress as a game is simulated play-by-play.