### PR TITLE
feat(league): add conferences and divisions

### DIFF
--- a/src/league/season.rs
+++ b/src/league/season.rs
@@ -1,16 +1,19 @@
 #![doc = include_str!("../../docs/league/season.md")]
+pub mod conference;
 pub mod matchup;
 pub mod playoffs;
 pub mod week;
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use crate::team::FootballTeam;
 use crate::league::matchup::LeagueTeamRecord;
+use crate::league::season::conference::{LeagueConference, LeagueDivision};
 use crate::league::season::week::LeagueSeasonWeek;
 use crate::league::season::matchup::{LeagueSeasonMatchup, LeagueSeasonMatchups};
 use crate::league::season::playoffs::LeagueSeasonPlayoffs;
 use crate::league::season::playoffs::picture::PlayoffPicture;
+use crate::game::matchup::FootballMatchupResult;
 use crate::game::play::{Game, GameSimulator};
 
 #[cfg(feature = "rocket_okapi")]
@@ -30,6 +33,8 @@ use serde::{Serialize, Deserialize, Deserializer};
 pub struct LeagueSeasonRaw {
     pub year: usize,
     pub teams: BTreeMap<usize, FootballTeam>,
+    #[serde(default)]
+    pub conferences: Vec<LeagueConference>,
     pub weeks: Vec<LeagueSeasonWeek>,
     pub playoffs: LeagueSeasonPlayoffs
 }
@@ -47,6 +52,7 @@ impl Default for LeagueSeasonRaw {
         LeagueSeasonRaw{
             year: chrono::Utc::now().year() as usize,
             teams: BTreeMap::new(),
+            conferences: Vec::new(),
             weeks: Vec::new(),
             playoffs: LeagueSeasonPlayoffs::new()
         }
@@ -190,6 +196,27 @@ impl LeagueSeasonRaw {
             }
         }
 
+        // Validate conference team IDs
+        let mut seen_conference_teams = HashSet::new();
+        for (conf_index, conference) in self.conferences.iter().enumerate() {
+            for &team_id in &conference.all_teams() {
+                // Ensure the team ID exists in the season
+                if !self.teams.contains_key(&team_id) {
+                    return Err(format!(
+                        "Conference {} ('{}') references nonexistent team ID: {}",
+                        conf_index, conference.name(), team_id
+                    ));
+                }
+                // Ensure no duplicate team IDs across conferences
+                if !seen_conference_teams.insert(team_id) {
+                    return Err(format!(
+                        "Duplicate team ID {} found across conferences (detected in conference {} '{}')",
+                        team_id, conf_index, conference.name()
+                    ));
+                }
+            }
+        }
+
         // Validate the season weeks
         let mut prev_started: bool = false;
         let mut prev_completed: bool = false;
@@ -281,7 +308,13 @@ impl LeagueSeasonRaw {
 pub struct LeagueSeasonScheduleOptions {
     pub weeks: Option<usize>,
     pub shift: Option<usize>,
-    pub permute: Option<bool>
+    pub permute: Option<bool>,
+    /// Number of games per division opponent (default: 2)
+    pub division_games: Option<usize>,
+    /// Number of games per non-division conference opponent (default: 1)
+    pub conference_games: Option<usize>,
+    /// Total number of cross-conference games per team (default: 0)
+    pub cross_conference_games: Option<usize>,
 }
 
 impl Default for LeagueSeasonScheduleOptions {
@@ -297,7 +330,10 @@ impl Default for LeagueSeasonScheduleOptions {
         LeagueSeasonScheduleOptions{
             weeks: None,
             shift: None,
-            permute: None
+            permute: None,
+            division_games: None,
+            conference_games: None,
+            cross_conference_games: None,
         }
     }
 }
@@ -316,6 +352,50 @@ impl LeagueSeasonScheduleOptions {
     }
 }
 
+/// # `LeagueSeasonPlayoffOptions` struct
+///
+/// Options for generating playoffs. Supports both single-bracket and
+/// multi-conference bracket modes.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize, Deserialize)]
+pub struct LeagueSeasonPlayoffOptions {
+    /// Total number of playoff teams (used when not using conference brackets)
+    pub num_playoff_teams: usize,
+    /// If true and the league has multiple conferences, use separate conference
+    /// brackets plus a winners bracket for conference champions
+    pub use_conference_brackets: bool,
+    /// Number of playoff teams per conference (only used when
+    /// `use_conference_brackets` is true and the league has multiple conferences)
+    pub playoff_teams_per_conference: usize,
+    /// If true, division winners are guaranteed playoff spots regardless of
+    /// record (only used when `use_conference_brackets` is true)
+    pub division_winners_guaranteed: bool,
+}
+
+impl Default for LeagueSeasonPlayoffOptions {
+    fn default() -> Self {
+        LeagueSeasonPlayoffOptions {
+            num_playoff_teams: 2,
+            use_conference_brackets: false,
+            playoff_teams_per_conference: 2,
+            division_winners_guaranteed: false,
+        }
+    }
+}
+
+impl LeagueSeasonPlayoffOptions {
+    /// Constructor for the `LeagueSeasonPlayoffOptions` struct
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::LeagueSeasonPlayoffOptions;
+    ///
+    /// let my_playoff_options = LeagueSeasonPlayoffOptions::new();
+    /// ```
+    pub fn new() -> LeagueSeasonPlayoffOptions {
+        LeagueSeasonPlayoffOptions::default()
+    }
+}
+
 /// # `LeagueSeason` struct
 ///
 /// A `LeagueSeason` represents a season of a football league.
@@ -324,6 +404,7 @@ impl LeagueSeasonScheduleOptions {
 pub struct LeagueSeason {
     year: usize,
     teams: BTreeMap<usize, FootballTeam>,
+    conferences: Vec<LeagueConference>,
     weeks: Vec<LeagueSeasonWeek>,
     playoffs: LeagueSeasonPlayoffs
 }
@@ -343,6 +424,7 @@ impl TryFrom<LeagueSeasonRaw> for LeagueSeason {
             LeagueSeason{
                 year: item.year,
                 teams: item.teams,
+                conferences: item.conferences,
                 weeks: item.weeks,
                 playoffs: item.playoffs
             }
@@ -375,6 +457,7 @@ impl Default for LeagueSeason {
         LeagueSeason{
             year: chrono::Utc::now().year() as usize,
             teams: BTreeMap::new(),
+            conferences: Vec::new(),
             weeks: Vec::new(),
             playoffs: LeagueSeasonPlayoffs::new()
         }
@@ -548,6 +631,216 @@ impl LeagueSeason {
         self.teams.get_mut(&id)
     }
 
+    /// Borrow the conferences in the season
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::LeagueSeason;
+    ///
+    /// let season = LeagueSeason::new();
+    /// let conferences = season.conferences();
+    /// ```
+    pub fn conferences(&self) -> &Vec<LeagueConference> {
+        &self.conferences
+    }
+
+    /// Mutably borrow the conferences in the season
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::LeagueSeason;
+    ///
+    /// let mut season = LeagueSeason::new();
+    /// let conferences = season.conferences_mut();
+    /// ```
+    pub fn conferences_mut(&mut self) -> &mut Vec<LeagueConference> {
+        &mut self.conferences
+    }
+
+    /// Add a conference to the season
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::LeagueSeason;
+    /// use fbsim_core::league::season::conference::LeagueConference;
+    ///
+    /// let mut season = LeagueSeason::new();
+    /// let conference = LeagueConference::with_name("AFC");
+    /// season.add_conference(conference);
+    /// ```
+    pub fn add_conference(&mut self, conference: LeagueConference) -> Result<(), String> {
+        let existing_teams: Vec<usize> = self
+            .conferences
+            .iter()
+            .flat_map(|c| c.all_teams())
+            .collect();
+        for team_id in conference.all_teams() {
+            if existing_teams.contains(&team_id) {
+                return Err(format!(
+                    "Team with ID {} already exists in another conference",
+                    team_id
+                ));
+            }
+        }
+        self.conferences.push(conference);
+        Ok(())
+    }
+
+    /// Get a conference by index
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::LeagueSeason;
+    /// use fbsim_core::league::season::conference::LeagueConference;
+    ///
+    /// let mut season = LeagueSeason::new();
+    /// season.add_conference(LeagueConference::with_name("AFC"));
+    /// let conference = season.conference(0);
+    /// assert!(conference.is_some());
+    /// ```
+    pub fn conference(&self, index: usize) -> Option<&LeagueConference> {
+        self.conferences.get(index)
+    }
+
+    /// Get a mutable conference by index
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::LeagueSeason;
+    /// use fbsim_core::league::season::conference::LeagueConference;
+    ///
+    /// let mut season = LeagueSeason::new();
+    /// season.add_conference(LeagueConference::with_name("AFC"));
+    /// let conference = season.conference_mut(0);
+    /// assert!(conference.is_some());
+    /// ```
+    pub fn conference_mut(&mut self, index: usize) -> Option<&mut LeagueConference> {
+        self.conferences.get_mut(index)
+    }
+
+    /// Find which conference a team belongs to (returns conference index)
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::LeagueSeason;
+    /// use fbsim_core::league::season::conference::{LeagueConference, LeagueDivision};
+    ///
+    /// let mut season = LeagueSeason::new();
+    /// let mut conf = LeagueConference::with_name("AFC");
+    /// let mut div = LeagueDivision::with_name("East");
+    /// div.add_team(0);
+    /// conf.add_division(div);
+    /// season.add_conference(conf);
+    ///
+    /// assert_eq!(season.team_conference(0), Some(0));
+    /// assert_eq!(season.team_conference(99), None);
+    /// ```
+    pub fn team_conference(&self, team_id: usize) -> Option<usize> {
+        for (conf_index, conference) in self.conferences.iter().enumerate() {
+            if conference.contains_team(team_id) {
+                return Some(conf_index);
+            }
+        }
+        None
+    }
+
+    /// Find which division a team belongs to (returns conference index and division id)
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::LeagueSeason;
+    /// use fbsim_core::league::season::conference::{LeagueConference, LeagueDivision};
+    ///
+    /// let mut season = LeagueSeason::new();
+    /// let mut conf = LeagueConference::with_name("AFC");
+    /// let mut div = LeagueDivision::with_name("East");
+    /// div.add_team(0);
+    /// conf.add_division(div);
+    /// season.add_conference(conf);
+    ///
+    /// assert_eq!(season.team_division(0), Some((0, 0)));
+    /// assert_eq!(season.team_division(99), None);
+    /// ```
+    pub fn team_division(&self, team_id: usize) -> Option<(usize, usize)> {
+        for (conf_index, conference) in self.conferences.iter().enumerate() {
+            if let Some(div_id) = conference.team_division(team_id) {
+                return Some((conf_index, div_id));
+            }
+        }
+        None
+    }
+
+    /// Check if two teams are in the same division
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::LeagueSeason;
+    /// use fbsim_core::league::season::conference::{LeagueConference, LeagueDivision};
+    ///
+    /// let mut season = LeagueSeason::new();
+    /// let mut conf = LeagueConference::new();
+    /// let mut div1 = LeagueDivision::new();
+    /// div1.add_team(0);
+    /// div1.add_team(1);
+    /// let mut div2 = LeagueDivision::new();
+    /// div2.add_team(2);
+    /// div2.add_team(3);
+    /// conf.add_division(div1);
+    /// conf.add_division(div2);
+    /// season.add_conference(conf);
+    ///
+    /// assert!(season.same_division(0, 1));
+    /// assert!(!season.same_division(0, 2));
+    /// ```
+    pub fn same_division(&self, team1: usize, team2: usize) -> bool {
+        match (self.team_division(team1), self.team_division(team2)) {
+            (Some((conf1, div1)), Some((conf2, div2))) => conf1 == conf2 && div1 == div2,
+            _ => false,
+        }
+    }
+
+    /// Check if two teams are in the same conference
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::LeagueSeason;
+    /// use fbsim_core::league::season::conference::{LeagueConference, LeagueDivision};
+    ///
+    /// let mut season = LeagueSeason::new();
+    ///
+    /// // AFC with two divisions
+    /// let mut afc = LeagueConference::with_name("AFC");
+    /// let mut afc_east = LeagueDivision::with_name("East");
+    /// afc_east.add_team(0);
+    /// afc_east.add_team(1);
+    /// let mut afc_west = LeagueDivision::with_name("West");
+    /// afc_west.add_team(2);
+    /// afc_west.add_team(3);
+    /// afc.add_division(afc_east);
+    /// afc.add_division(afc_west);
+    ///
+    /// // NFC with one division
+    /// let mut nfc = LeagueConference::with_name("NFC");
+    /// let mut nfc_east = LeagueDivision::with_name("East");
+    /// nfc_east.add_team(4);
+    /// nfc_east.add_team(5);
+    /// nfc.add_division(nfc_east);
+    ///
+    /// season.add_conference(afc);
+    /// season.add_conference(nfc);
+    ///
+    /// // Teams 0 and 2 are in same conference (AFC) but different divisions
+    /// assert!(season.same_conference(0, 2));
+    /// // Teams 0 and 4 are in different conferences
+    /// assert!(!season.same_conference(0, 4));
+    /// ```
+    pub fn same_conference(&self, team1: usize, team2: usize) -> bool {
+        match (self.team_conference(team1), self.team_conference(team2)) {
+            (Some(conf1), Some(conf2)) => conf1 == conf2,
+            _ => false,
+        }
+    }
+
     /// Borrow the weeks of the season
     ///
     /// ### Example
@@ -665,6 +958,31 @@ impl LeagueSeason {
         }
     }
 
+    /// Create a default conference structure with a single conference and division
+    /// containing all teams. Used when no conferences are defined but schedule
+    /// generation is requested.
+    fn create_default_conference(&mut self) {
+        let mut division = LeagueDivision::with_name("Default");
+        for team_id in self.teams.keys() {
+            division.add_team(*team_id).expect("default conference has unique team IDs");
+        }
+
+        let mut conference = LeagueConference::with_name("Default");
+        conference.add_division(division).expect("default conference has a single division");
+
+        self.conferences.clear();
+        self.conferences.push(conference);
+    }
+
+    /// Check if conference-aware (structured) scheduling is needed
+    fn needs_structured_scheduling(&self) -> bool {
+        // Need structured scheduling if:
+        // 1. Multiple conferences exist
+        // 2. Any conference has multiple divisions
+        self.conferences.len() > 1
+            || self.conferences.iter().any(|c| c.divisions().len() > 1)
+    }
+
     /// Generate a schedule for the season.  The generated schedule is a round
     /// robin schedule in which each team plays an equal number of home and
     /// away games, and in which each team plays each other twice.
@@ -689,6 +1007,36 @@ impl LeagueSeason {
     /// my_league_season.generate_schedule(LeagueSeasonScheduleOptions::new(), &mut rng);
     /// ```
     pub fn generate_schedule(&mut self, options: LeagueSeasonScheduleOptions, rng: &mut impl Rng) -> Result<(), String> {
+        // If no conferences defined, create default single conference with all teams
+        if self.conferences.is_empty() {
+            self.create_default_conference();
+        }
+
+        // Validate that divisions within each conference are of equal size
+        for conference in &self.conferences {
+            let div_sizes: Vec<usize> = conference.divisions().iter()
+                .map(|d| d.num_teams())
+                .collect();
+            if let Some(&first) = div_sizes.first() {
+                if div_sizes.iter().any(|&s| s != first) {
+                    return Err(format!(
+                        "Conference '{}' has divisions of unequal size: {:?}",
+                        conference.name(), div_sizes
+                    ));
+                }
+            }
+        }
+
+        // Route to appropriate schedule generation method
+        if self.needs_structured_scheduling() {
+            self.generate_structured_schedule(options, rng)
+        } else {
+            self.generate_round_robin_schedule(options, rng)
+        }
+    }
+
+    /// Generate a simple round-robin schedule (existing algorithm)
+    fn generate_round_robin_schedule(&mut self, options: LeagueSeasonScheduleOptions, rng: &mut impl Rng) -> Result<(), String> {
         // Check whether there are at least 4 teams, an even number of teams
         let num_teams = self.teams.len();
         if num_teams < 4 {
@@ -836,6 +1184,313 @@ impl LeagueSeason {
         Ok(())
     }
 
+    /// Generate a conference-aware structured schedule
+    fn generate_structured_schedule(&mut self, options: LeagueSeasonScheduleOptions, rng: &mut impl Rng) -> Result<(), String> {
+        // Validate basic requirements
+        let num_teams = self.teams.len();
+        if num_teams < 4 {
+            return Err(format!("Less than 4 teams, not enough teams to generate a schedule: {}", num_teams));
+        }
+
+        // Check to make sure the season has not already started
+        if self.started() {
+            return Err("Season has already started, cannot re-generate schedule".to_string());
+        }
+
+        // Clear existing schedule
+        if !self.weeks.is_empty() {
+            self.weeks.clear();
+        }
+
+        // Get scheduling parameters with defaults
+        let division_games = options.division_games.unwrap_or(2);
+        let conference_games = options.conference_games.unwrap_or(1);
+        let cross_conference_games = options.cross_conference_games.unwrap_or(0);
+
+        // Generate all matchups as (home_id, away_id) tuples
+        let mut all_matchups: Vec<(usize, usize)> = Vec::new();
+
+        // Phase 1: Division matchups
+        let division_matchups = self.generate_division_matchups(division_games, rng)?;
+        all_matchups.extend(division_matchups);
+
+        // Phase 2: Conference (non-division) matchups
+        let conference_matchups = self.generate_conference_matchups(conference_games, rng)?;
+        all_matchups.extend(conference_matchups);
+
+        // Phase 3: Cross-conference matchups
+        if cross_conference_games > 0 {
+            let cross_conf_matchups = self.generate_cross_conference_matchups(cross_conference_games, rng)?;
+            all_matchups.extend(cross_conf_matchups);
+        }
+
+        // Phase 4: Interleave matchups into weeks
+        self.interleave_matchups(all_matchups, rng)?;
+
+        // Get the shift option value
+        let shift = options.shift.unwrap_or(0);
+        if shift > 0 && shift <= self.weeks.len() {
+            self.weeks.rotate_right(shift);
+        }
+
+        // If desired, randomly permute the weeks of the season
+        if let Some(true) = options.permute {
+            self.weeks.shuffle(rng);
+        }
+
+        Ok(())
+    }
+
+    /// Generate intra-division matchups using circle method within each division
+    fn generate_division_matchups(&self, games_per_opponent: usize, rng: &mut impl Rng) -> Result<Vec<(usize, usize)>, String> {
+        let mut matchups = Vec::new();
+
+        for conference in &self.conferences {
+            for division in conference.divisions().iter() {
+                let teams: Vec<usize> = division.teams().clone();
+                let n = teams.len();
+
+                if n < 2 {
+                    continue; // Skip divisions with less than 2 teams
+                }
+
+                // Generate round-robin matchups within division
+                let div_matchups = self.circle_method_matchups(&teams, games_per_opponent, rng)?;
+                matchups.extend(div_matchups);
+            }
+        }
+
+        Ok(matchups)
+    }
+
+    /// Generate intra-conference (cross-division) matchups
+    fn generate_conference_matchups(&self, games_per_opponent: usize, rng: &mut impl Rng) -> Result<Vec<(usize, usize)>, String> {
+        let mut matchups = Vec::new();
+
+        if games_per_opponent == 0 {
+            return Ok(matchups);
+        }
+
+        for conference in &self.conferences {
+            // Get all teams in this conference
+            let all_teams = conference.all_teams();
+
+            // For each pair of teams in the same conference but different divisions
+            for i in 0..all_teams.len() {
+                for j in (i + 1)..all_teams.len() {
+                    let team1 = all_teams[i];
+                    let team2 = all_teams[j];
+
+                    // Skip if same division (already handled in division matchups)
+                    if self.same_division(team1, team2) {
+                        continue;
+                    }
+
+                    // Generate the specified number of games
+                    for cycle in 0..games_per_opponent {
+                        // Alternate home/away
+                        if cycle % 2 == 0 {
+                            matchups.push((team1, team2));
+                        } else {
+                            matchups.push((team2, team1));
+                        }
+                    }
+                }
+            }
+        }
+
+        // Shuffle to add variety
+        matchups.shuffle(rng);
+        Ok(matchups)
+    }
+
+    /// Generate cross-conference matchups
+    fn generate_cross_conference_matchups(&self, total_games_per_team: usize, rng: &mut impl Rng) -> Result<Vec<(usize, usize)>, String> {
+        let mut matchups = Vec::new();
+
+        if self.conferences.len() < 2 || total_games_per_team == 0 {
+            return Ok(matchups);
+        }
+
+        // Track how many cross-conference games each team has scheduled
+        let mut team_cross_conf_games: HashMap<usize, usize> = HashMap::new();
+        for team_id in self.teams.keys() {
+            team_cross_conf_games.insert(*team_id, 0);
+        }
+
+        // Get all possible cross-conference pairs
+        let mut possible_pairs: Vec<(usize, usize)> = Vec::new();
+        for (i, conf1) in self.conferences.iter().enumerate() {
+            for conf2 in self.conferences.iter().skip(i + 1) {
+                let teams1 = conf1.all_teams();
+                let teams2 = conf2.all_teams();
+
+                for t1 in &teams1 {
+                    for t2 in &teams2 {
+                        possible_pairs.push((*t1, *t2));
+                    }
+                }
+            }
+        }
+
+        // Shuffle pairs for randomness
+        possible_pairs.shuffle(rng);
+
+        // Greedily assign cross-conference games
+        for (team1, team2) in possible_pairs {
+            let games1 = *team_cross_conf_games.get(&team1).unwrap_or(&0);
+            let games2 = *team_cross_conf_games.get(&team2).unwrap_or(&0);
+
+            if games1 < total_games_per_team && games2 < total_games_per_team {
+                // Randomly decide home/away
+                if rng.gen::<bool>() {
+                    matchups.push((team1, team2));
+                } else {
+                    matchups.push((team2, team1));
+                }
+                *team_cross_conf_games.get_mut(&team1).unwrap() += 1;
+                *team_cross_conf_games.get_mut(&team2).unwrap() += 1;
+            }
+        }
+
+        Ok(matchups)
+    }
+
+    /// Apply circle method to generate round-robin matchups for a set of teams
+    fn circle_method_matchups(&self, teams: &[usize], games_per_opponent: usize, rng: &mut impl Rng) -> Result<Vec<(usize, usize)>, String> {
+        let mut matchups = Vec::new();
+        let n = teams.len();
+
+        if n < 2 {
+            return Ok(matchups);
+        }
+
+        // Shuffle teams for variety
+        let mut team_ids = teams.to_vec();
+        team_ids.shuffle(rng);
+
+        let num_rounds = n - 1;
+        let num_matchups_per_round = n / 2;
+
+        // Generate games_per_opponent cycles of round-robin
+        for cycle in 0..games_per_opponent {
+            for round in 0..num_rounds {
+                // Build arrangement using circle method
+                let mut arrangement: Vec<usize> = Vec::with_capacity(n);
+                arrangement.push(team_ids[0]); // Fixed team
+                for i in 0..(n - 1) {
+                    let rotated_index = (i + (n - 1) - round) % (n - 1);
+                    arrangement.push(team_ids[1 + rotated_index]);
+                }
+
+                // Create matchups
+                for m in 0..num_matchups_per_round {
+                    let team1 = arrangement[m];
+                    let team2 = arrangement[n - 1 - m];
+
+                    // Alternate home/away based on cycle
+                    if cycle % 2 == 0 {
+                        matchups.push((team1, team2));
+                    } else {
+                        matchups.push((team2, team1));
+                    }
+                }
+            }
+        }
+
+        Ok(matchups)
+    }
+
+    /// Interleave matchups into weeks, avoiding long road trips
+    fn interleave_matchups(&mut self, matchups: Vec<(usize, usize)>, rng: &mut impl Rng) -> Result<(), String> {
+        if matchups.is_empty() {
+            return Ok(());
+        }
+
+        let num_teams = self.teams.len();
+        let _matchups_per_week = num_teams / 2;
+
+        // Track home/away streaks and which matchups are scheduled
+        let mut remaining_matchups: Vec<(usize, usize)> = matchups;
+        remaining_matchups.shuffle(rng); // Shuffle for variety
+
+        let mut team_away_streak: HashMap<usize, usize> = HashMap::new();
+        let mut team_home_streak: HashMap<usize, usize> = HashMap::new();
+        for id in self.teams.keys() {
+            team_away_streak.insert(*id, 0);
+            team_home_streak.insert(*id, 0);
+        }
+
+        while !remaining_matchups.is_empty() {
+            let mut week = LeagueSeasonWeek::new();
+            let mut teams_scheduled_this_week: HashSet<usize> = HashSet::new();
+            let mut matchups_this_week: Vec<usize> = Vec::new(); // indices into remaining_matchups
+
+            // Greedily select matchups for this week
+            for (index, (home_id, away_id)) in remaining_matchups.iter().enumerate() {
+                // Skip if either team already scheduled this week
+                if teams_scheduled_this_week.contains(home_id) || teams_scheduled_this_week.contains(away_id) {
+                    continue;
+                }
+
+                // Check road trip constraint (no more than 2 consecutive away games)
+                let away_streak = *team_away_streak.get(away_id).unwrap_or(&0);
+                if away_streak >= 2 {
+                    // Check if there's an alternative where this team is home
+                    // For now, we'll allow it but prefer not to
+                    // This could be improved with backtracking
+                }
+
+                // Schedule this matchup
+                teams_scheduled_this_week.insert(*home_id);
+                teams_scheduled_this_week.insert(*away_id);
+                matchups_this_week.push(index);
+
+                if teams_scheduled_this_week.len() >= num_teams {
+                    break; // Week is full
+                }
+            }
+
+            // If we couldn't schedule any matchups but there are still remaining, force one
+            if matchups_this_week.is_empty() && !remaining_matchups.is_empty() {
+                matchups_this_week.push(0);
+                let (home_id, away_id) = remaining_matchups[0];
+                teams_scheduled_this_week.insert(home_id);
+                teams_scheduled_this_week.insert(away_id);
+            }
+
+            // Create matchups and update streaks
+            // Sort indices in reverse so we can remove from end first
+            matchups_this_week.sort_by(|a, b| b.cmp(a));
+            for index in matchups_this_week {
+                let (home_id, away_id) = remaining_matchups.remove(index);
+
+                // Get team short names
+                let home_short_name = self.teams.get(&home_id).unwrap().short_name();
+                let away_short_name = self.teams.get(&away_id).unwrap().short_name();
+
+                // Create matchup
+                let matchup = LeagueSeasonMatchup::new(home_id, away_id, home_short_name, away_short_name, rng);
+                week.matchups_mut().push(matchup);
+
+                // Update streaks
+                *team_home_streak.get_mut(&home_id).unwrap() += 1;
+                *team_away_streak.get_mut(&home_id).unwrap() = 0;
+                *team_away_streak.get_mut(&away_id).unwrap() += 1;
+                *team_home_streak.get_mut(&away_id).unwrap() = 0;
+            }
+
+            self.weeks.push(week);
+
+            // Safety: prevent infinite loop
+            if self.weeks.len() > num_teams * 10 {
+                return Err("Failed to generate valid schedule - too many weeks".to_string());
+            }
+        }
+
+        Ok(())
+    }
+
     /// Computes the season standings sorted in descending order, mapping
     /// team IDs to their season record
     ///
@@ -915,6 +1570,333 @@ impl LeagueSeason {
         standings
     }
 
+    /// Computes the division standings for a specific division
+    ///
+    /// ### Arguments
+    /// * `conf_index` - The conference index (position in conferences Vec)
+    /// * `div_id` - The division ID (key in conference's divisions BTreeMap)
+    ///
+    /// ### Returns
+    /// * `Ok(Vec<(usize, LeagueTeamRecord)>)` - Division standings sorted by record
+    /// * `Err(String)` - If conference or division doesn't exist
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::FootballTeam;
+    /// use fbsim_core::league::season::LeagueSeason;
+    /// use fbsim_core::league::season::LeagueSeasonScheduleOptions;
+    /// use fbsim_core::league::season::conference::{LeagueConference, LeagueDivision};
+    ///
+    /// // Create a new season with 2 conferences
+    /// let mut my_league_season = LeagueSeason::new();
+    ///
+    /// // Add teams
+    /// my_league_season.add_team(0, FootballTeam::new());
+    /// my_league_season.add_team(1, FootballTeam::new());
+    /// my_league_season.add_team(2, FootballTeam::new());
+    /// my_league_season.add_team(3, FootballTeam::new());
+    ///
+    /// // Create conference structure
+    /// let mut afc = LeagueConference::with_name("AFC");
+    /// let mut afc_div = LeagueDivision::with_name("East");
+    /// afc_div.add_team(0);
+    /// afc_div.add_team(1);
+    /// afc.add_division(afc_div);
+    /// my_league_season.add_conference(afc);
+    ///
+    /// let mut nfc = LeagueConference::with_name("NFC");
+    /// let mut nfc_div = LeagueDivision::with_name("East");
+    /// nfc_div.add_team(2);
+    /// nfc_div.add_team(3);
+    /// nfc.add_division(nfc_div);
+    /// my_league_season.add_conference(nfc);
+    ///
+    /// // Compute the division standings
+    /// let afc_east_standings = my_league_season.division_standings(0, 0);
+    /// if let Err(ref e) = afc_east_standings {
+    ///     println!("{}", e);
+    /// }
+    /// assert!(afc_east_standings.is_ok());
+    /// ```
+    pub fn division_standings(&self, conf_index: usize, div_id: usize) -> Result<Vec<(usize, LeagueTeamRecord)>, String> {
+        // Get the conference
+        let conference = self.conferences.get(conf_index)
+            .ok_or_else(|| format!("Conference index {} does not exist", conf_index))?;
+
+        // Get the division
+        let division = conference.division(div_id)
+            .ok_or_else(|| format!("Division {} does not exist in conference {}", div_id, conf_index))?;
+
+        // Get all standings and filter to this division's teams
+        let all_standings = self.standings();
+        let division_teams: HashSet<usize> = division.teams().iter().cloned().collect();
+
+        let standings: Vec<(usize, LeagueTeamRecord)> = all_standings
+            .into_iter()
+            .filter(|(id, _)| division_teams.contains(id))
+            .collect();
+
+        Ok(standings)
+    }
+
+    /// Computes the conference standings for a specific conference
+    ///
+    /// ### Arguments
+    /// * `conf_index` - The conference index (position in conferences Vec)
+    ///
+    /// ### Returns
+    /// * `Ok(Vec<(usize, LeagueTeamRecord)>)` - Conference standings sorted by record
+    /// * `Err(String)` - If conference doesn't exist
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::FootballTeam;
+    /// use fbsim_core::league::season::LeagueSeason;
+    /// use fbsim_core::league::season::LeagueSeasonScheduleOptions;
+    /// use fbsim_core::league::season::conference::{LeagueConference, LeagueDivision};
+    ///
+    /// // Create a new season with 2 conferences
+    /// let mut my_league_season = LeagueSeason::new();
+    ///
+    /// // Add teams
+    /// my_league_season.add_team(0, FootballTeam::new());
+    /// my_league_season.add_team(1, FootballTeam::new());
+    /// my_league_season.add_team(2, FootballTeam::new());
+    /// my_league_season.add_team(3, FootballTeam::new());
+    ///
+    /// // Create conference structure
+    /// let mut afc = LeagueConference::with_name("AFC");
+    /// let mut afc_div = LeagueDivision::with_name("East");
+    /// afc_div.add_team(0);
+    /// afc_div.add_team(1);
+    /// afc.add_division(afc_div);
+    /// my_league_season.add_conference(afc);
+    ///
+    /// let mut nfc = LeagueConference::with_name("NFC");
+    /// let mut nfc_div = LeagueDivision::with_name("East");
+    /// nfc_div.add_team(2);
+    /// nfc_div.add_team(3);
+    /// nfc.add_division(nfc_div);
+    /// my_league_season.add_conference(nfc);
+    ///
+    /// // Compute the conference standings
+    /// let nfc_standings = my_league_season.conference_standings(1);
+    /// assert!(nfc_standings.is_ok());
+    /// ```
+    pub fn conference_standings(&self, conf_index: usize) -> Result<Vec<(usize, LeagueTeamRecord)>, String> {
+        // Get the conference
+        let conference = self.conferences.get(conf_index)
+            .ok_or_else(|| format!("Conference index {} does not exist", conf_index))?;
+
+        // Get all teams in the conference
+        let conference_teams: HashSet<usize> = conference.all_teams().into_iter().collect();
+
+        // Get all standings and filter to this conference's teams
+        let all_standings = self.standings();
+
+        let standings: Vec<(usize, LeagueTeamRecord)> = all_standings
+            .into_iter()
+            .filter(|(id, _)| conference_teams.contains(id))
+            .collect();
+
+        Ok(standings)
+    }
+
+    /// Computes a team's record against division opponents only
+    ///
+    /// ### Arguments
+    /// * `team_id` - The team ID to compute division record for
+    ///
+    /// ### Returns
+    /// * `Ok(LeagueTeamRecord)` - The team's record against division opponents
+    /// * `Err(String)` - If team doesn't exist or has no division assignment
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::FootballTeam;
+    /// use fbsim_core::league::season::LeagueSeason;
+    /// use fbsim_core::league::season::LeagueSeasonScheduleOptions;
+    /// use fbsim_core::league::season::conference::{LeagueConference, LeagueDivision};
+    ///
+    /// // Create a new season with 2 conferences
+    /// let mut my_league_season = LeagueSeason::new();
+    ///
+    /// // Add teams
+    /// my_league_season.add_team(0, FootballTeam::new());
+    /// my_league_season.add_team(1, FootballTeam::new());
+    /// my_league_season.add_team(2, FootballTeam::new());
+    /// my_league_season.add_team(3, FootballTeam::new());
+    ///
+    /// // Create conference structure
+    /// let mut afc = LeagueConference::with_name("AFC");
+    /// let mut afc_div = LeagueDivision::with_name("East");
+    /// afc_div.add_team(0);
+    /// afc_div.add_team(1);
+    /// afc.add_division(afc_div);
+    /// my_league_season.add_conference(afc);
+    ///
+    /// let mut nfc = LeagueConference::with_name("NFC");
+    /// let mut nfc_div = LeagueDivision::with_name("East");
+    /// nfc_div.add_team(2);
+    /// nfc_div.add_team(3);
+    /// nfc.add_division(nfc_div);
+    /// my_league_season.add_conference(nfc);
+    ///
+    /// // Generate the season schedule and simulate the season
+    /// let mut rng = rand::thread_rng();
+    /// my_league_season.generate_schedule(LeagueSeasonScheduleOptions::new(), &mut rng);
+    /// my_league_season.sim_regular_season(&mut rng);
+    ///
+    /// // Calculate team 2's division record
+    /// let record = my_league_season.division_record(2);
+    /// assert!(record.is_ok());
+    /// ```
+    pub fn division_record(&self, team_id: usize) -> Result<LeagueTeamRecord, String> {
+        // Find team's division
+        let (conf_index, div_id) = self.team_division(team_id)
+            .ok_or_else(|| format!("Team {} has no division assignment", team_id))?;
+
+        // Get division teams
+        let division = self.conferences.get(conf_index)
+            .and_then(|c| c.division(div_id))
+            .ok_or_else(|| format!("Division not found for team {}", team_id))?;
+
+        let division_teams: HashSet<usize> = division.teams().iter().cloned().collect();
+
+        // Compute record against division opponents
+        let mut record = LeagueTeamRecord::new();
+
+        for week in &self.weeks {
+            for matchup in week.matchups() {
+                if !matchup.context().game_over() {
+                    continue;
+                }
+
+                let home = *matchup.home_team();
+                let away = *matchup.away_team();
+
+                // Check if this is a division game involving our team
+                let is_our_game = home == team_id || away == team_id;
+                let opponent = if home == team_id { away } else { home };
+                let is_division_game = division_teams.contains(&opponent);
+
+                if is_our_game && is_division_game {
+                    match matchup.result(team_id) {
+                        Some(FootballMatchupResult::Win) => {
+                            record.increment_wins(1);
+                        }
+                        Some(FootballMatchupResult::Loss) => {
+                            record.increment_losses(1);
+                        }
+                        Some(FootballMatchupResult::Tie) => {
+                            record.increment_ties(1);
+                        }
+                        None => {}
+                    }
+                }
+            }
+        }
+
+        Ok(record)
+    }
+
+    /// Computes a team's record against conference opponents only
+    ///
+    /// ### Arguments
+    /// * `team_id` - The team ID to compute conference record for
+    ///
+    /// ### Returns
+    /// * `Ok(LeagueTeamRecord)` - The team's record against conference opponents
+    /// * `Err(String)` - If team doesn't exist or has no conference assignment
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::FootballTeam;
+    /// use fbsim_core::league::season::LeagueSeason;
+    /// use fbsim_core::league::season::LeagueSeasonScheduleOptions;
+    /// use fbsim_core::league::season::conference::{LeagueConference, LeagueDivision};
+    ///
+    /// // Create a new season with 2 conferences
+    /// let mut my_league_season = LeagueSeason::new();
+    ///
+    /// // Add teams
+    /// my_league_season.add_team(0, FootballTeam::new());
+    /// my_league_season.add_team(1, FootballTeam::new());
+    /// my_league_season.add_team(2, FootballTeam::new());
+    /// my_league_season.add_team(3, FootballTeam::new());
+    ///
+    /// // Create conference structure
+    /// let mut afc = LeagueConference::with_name("AFC");
+    /// let mut afc_div = LeagueDivision::with_name("East");
+    /// afc_div.add_team(0);
+    /// afc_div.add_team(1);
+    /// afc.add_division(afc_div);
+    /// my_league_season.add_conference(afc);
+    ///
+    /// let mut nfc = LeagueConference::with_name("NFC");
+    /// let mut nfc_div = LeagueDivision::with_name("East");
+    /// nfc_div.add_team(2);
+    /// nfc_div.add_team(3);
+    /// nfc.add_division(nfc_div);
+    /// my_league_season.add_conference(nfc);
+    ///
+    /// // Generate the season schedule and simulate the season
+    /// let mut rng = rand::thread_rng();
+    /// my_league_season.generate_schedule(LeagueSeasonScheduleOptions::new(), &mut rng);
+    /// my_league_season.sim_regular_season(&mut rng);
+    ///
+    /// // Calculate team 1's conference record
+    /// let record = my_league_season.conference_record(1);
+    /// assert!(record.is_ok());
+    /// ```
+    pub fn conference_record(&self, team_id: usize) -> Result<LeagueTeamRecord, String> {
+        // Find team's conference
+        let conf_index = self.team_conference(team_id)
+            .ok_or_else(|| format!("Team {} has no conference assignment", team_id))?;
+
+        // Get conference teams
+        let conference = self.conferences.get(conf_index)
+            .ok_or_else(|| format!("Conference not found for team {}", team_id))?;
+
+        let conference_teams: HashSet<usize> = conference.all_teams().into_iter().collect();
+
+        // Compute record against conference opponents
+        let mut record = LeagueTeamRecord::new();
+
+        for week in &self.weeks {
+            for matchup in week.matchups() {
+                if !matchup.context().game_over() {
+                    continue;
+                }
+
+                let home = *matchup.home_team();
+                let away = *matchup.away_team();
+
+                // Check if this is a conference game involving our team
+                let is_our_game = home == team_id || away == team_id;
+                let opponent = if home == team_id { away } else { home };
+                let is_conference_game = conference_teams.contains(&opponent);
+
+                if is_our_game && is_conference_game {
+                    match matchup.result(team_id) {
+                        Some(FootballMatchupResult::Win) => {
+                            record.increment_wins(1);
+                        }
+                        Some(FootballMatchupResult::Loss) => {
+                            record.increment_losses(1);
+                        }
+                        Some(FootballMatchupResult::Tie) => {
+                            record.increment_ties(1);
+                        }
+                        None => {}
+                    }
+                }
+            }
+        }
+
+        Ok(record)
+    }
+
     /// Generate the current playoff picture for the season
     ///
     /// ### Arguments
@@ -946,7 +1928,7 @@ impl LeagueSeason {
     /// assert!(picture.is_ok());
     /// ```
     pub fn playoff_picture(&self, num_playoff_teams: usize) -> Result<playoffs::picture::PlayoffPicture, String> {
-        PlayoffPicture::from_season(self, num_playoff_teams)
+        PlayoffPicture::from_season(self, num_playoff_teams, None)
     }
 
     /// Determine of a team participated in the playoffs
@@ -979,6 +1961,7 @@ impl LeagueSeason {
     /// use fbsim_core::team::FootballTeam;
     /// use fbsim_core::league::season::LeagueSeason;
     /// use fbsim_core::league::season::LeagueSeasonScheduleOptions;
+    /// use fbsim_core::league::season::LeagueSeasonPlayoffOptions;
     /// use fbsim_core::league::matchup::LeagueTeamRecord;
     ///
     /// // Create a new season
@@ -998,7 +1981,9 @@ impl LeagueSeason {
     /// my_league_season.sim_regular_season(&mut rng);
     ///
     /// // Generate playoffs with 4 teams
-    /// my_league_season.generate_playoffs(4, &mut rng);
+    /// let mut playoff_options = LeagueSeasonPlayoffOptions::new();
+    /// playoff_options.num_playoff_teams = 4;
+    /// my_league_season.generate_playoffs(playoff_options, &mut rng);
     ///
     /// // Simulate the playoffs
     /// my_league_season.sim_playoffs(&mut rng);
@@ -1065,13 +2050,14 @@ impl LeagueSeason {
         Ok(false)
     }
 
-    /// Generate the playoffs with the specified number of teams
+    /// Generate the playoffs
     ///
-    /// ### Example
+    /// ### Example (single bracket)
     /// ```
     /// use fbsim_core::team::FootballTeam;
     /// use fbsim_core::league::season::LeagueSeason;
     /// use fbsim_core::league::season::LeagueSeasonScheduleOptions;
+    /// use fbsim_core::league::season::LeagueSeasonPlayoffOptions;
     ///
     /// // Create a new season
     /// let mut my_league_season = LeagueSeason::new();
@@ -1090,10 +2076,58 @@ impl LeagueSeason {
     /// my_league_season.sim_regular_season(&mut rng);
     ///
     /// // Generate playoffs with 4 teams
-    /// let res = my_league_season.generate_playoffs(4, &mut rng);
+    /// let mut options = LeagueSeasonPlayoffOptions::new();
+    /// options.num_playoff_teams = 4;
+    /// let res = my_league_season.generate_playoffs(options, &mut rng);
     /// assert!(res.is_ok());
     /// ```
-    pub fn generate_playoffs(&mut self, num_playoff_teams: usize, rng: &mut impl Rng) -> Result<(), String> {
+    ///
+    /// ### Example (conference brackets)
+    /// ```
+    /// use fbsim_core::team::FootballTeam;
+    /// use fbsim_core::league::season::LeagueSeason;
+    /// use fbsim_core::league::season::LeagueSeasonScheduleOptions;
+    /// use fbsim_core::league::season::LeagueSeasonPlayoffOptions;
+    /// use fbsim_core::league::season::conference::{LeagueConference, LeagueDivision};
+    ///
+    /// // Create a new season with 2 conferences
+    /// let mut my_league_season = LeagueSeason::new();
+    ///
+    /// // Add teams
+    /// my_league_season.add_team(0, FootballTeam::new());
+    /// my_league_season.add_team(1, FootballTeam::new());
+    /// my_league_season.add_team(2, FootballTeam::new());
+    /// my_league_season.add_team(3, FootballTeam::new());
+    ///
+    /// // Create conference structure
+    /// let mut afc = LeagueConference::with_name("AFC");
+    /// let mut afc_div = LeagueDivision::with_name("East");
+    /// afc_div.add_team(0);
+    /// afc_div.add_team(1);
+    /// afc.add_division(afc_div);
+    /// my_league_season.add_conference(afc);
+    ///
+    /// let mut nfc = LeagueConference::with_name("NFC");
+    /// let mut nfc_div = LeagueDivision::with_name("East");
+    /// nfc_div.add_team(2);
+    /// nfc_div.add_team(3);
+    /// nfc.add_division(nfc_div);
+    /// my_league_season.add_conference(nfc);
+    ///
+    /// // Generate schedule and simulate
+    /// let mut rng = rand::thread_rng();
+    /// my_league_season.generate_schedule(LeagueSeasonScheduleOptions::new(), &mut rng);
+    /// my_league_season.sim_regular_season(&mut rng);
+    ///
+    /// // Generate conference playoffs (2 teams per conference)
+    /// let mut options = LeagueSeasonPlayoffOptions::new();
+    /// options.use_conference_brackets = true;
+    /// options.playoff_teams_per_conference = 2;
+    /// options.division_winners_guaranteed = true;
+    /// let res = my_league_season.generate_playoffs(options, &mut rng);
+    /// assert!(res.is_ok());
+    /// ```
+    pub fn generate_playoffs(&mut self, options: LeagueSeasonPlayoffOptions, rng: &mut impl Rng) -> Result<(), String> {
         // Ensure the regular season is complete
         if !self.regular_season_complete() {
             return Err(String::from("Cannot generate playoffs: Regular season is not complete"));
@@ -1104,42 +2138,139 @@ impl LeagueSeason {
             return Err(String::from("Cannot generate playoffs: Playoffs have already started"));
         }
 
-        // Validate the number of playoff teams
-        if num_playoff_teams < 2 {
-            return Err(format!("Playoffs must have at least 2 teams, got {}", num_playoff_teams));
-        }
-        if num_playoff_teams > self.teams.len() {
-            return Err(format!(
-                "Cannot have more playoff teams ({}) than season teams ({})",
-                num_playoff_teams, self.teams.len()
-            ));
-        }
-
-        // Get the standings and select the top teams
-        let standings = self.standings();
+        // Determine whether to use conference brackets
+        let use_conferences = options.use_conference_brackets && self.conferences.len() > 1;
 
         // Reset the playoffs
         self.playoffs = LeagueSeasonPlayoffs::new();
 
-        // Add the top teams to the playoffs in seed order
-        for (i, (team_id, _)) in standings.iter().enumerate() {
-            if i >= num_playoff_teams {
-                break;
+        if use_conferences {
+            // Multi-conference path
+            let playoff_teams_per_conference = options.playoff_teams_per_conference;
+            let division_winners_guaranteed = options.division_winners_guaranteed;
+
+            // Validate teams per conference
+            if playoff_teams_per_conference < 1 {
+                return Err("Playoffs must have at least 1 team per conference".to_string());
             }
 
-            // Get the team's short name for the playoff bracket
-            let team = match self.teams.get(team_id) {
-                Some(t) => t,
-                None => return Err(format!("Team {} not found in season", team_id))
-            };
-            let short_name = team.short_name();
+            // Validate that each conference has an equal number of teams
+            let conf_sizes: Vec<usize> = self.conferences.iter()
+                .map(|c| c.num_teams())
+                .collect();
+            if let Some(&first) = conf_sizes.first() {
+                if conf_sizes.iter().any(|&s| s != first) {
+                    return Err(format!(
+                        "Conferences have unequal number of teams: {:?}",
+                        conf_sizes
+                    ));
+                }
+            }
 
-            // Add the team to the playoffs
-            self.playoffs.add_team(*team_id, short_name)?;
+            // Process each conference
+            for (conf_index, conference) in self.conferences.iter().enumerate() {
+                // Validate that conference has enough teams
+                let conf_team_count = conference.num_teams();
+                if playoff_teams_per_conference > conf_team_count {
+                    return Err(format!(
+                        "Cannot have {} playoff teams in conference {} which only has {} teams",
+                        playoff_teams_per_conference,
+                        conference.name(),
+                        conf_team_count
+                    ));
+                }
+
+                // Get conference standings
+                let conf_standings = self.conference_standings(conf_index)?;
+
+                // Determine division winners if guaranteed spots
+                let mut division_winners: Vec<usize> = Vec::new();
+                if division_winners_guaranteed {
+                    for (div_id, _) in conference.divisions().iter().enumerate() {
+                        let div_standings = self.division_standings(conf_index, div_id)?;
+                        if let Some((winner_id, _)) = div_standings.first() {
+                            division_winners.push(*winner_id);
+                        }
+                    }
+                }
+
+                // Build playoff teams for this conference
+                let mut conf_playoff_teams: Vec<usize> = Vec::new();
+
+                // First, add division winners (in order of their conference standing)
+                let mut sorted_div_winners: Vec<(usize, usize)> = division_winners
+                    .iter()
+                    .filter_map(|&winner_id| {
+                        conf_standings
+                            .iter()
+                            .position(|(id, _)| *id == winner_id)
+                            .map(|pos| (pos, winner_id))
+                    })
+                    .collect();
+                sorted_div_winners.sort_by_key(|(pos, _)| *pos);
+
+                for (_, winner_id) in sorted_div_winners {
+                    if conf_playoff_teams.len() < playoff_teams_per_conference {
+                        conf_playoff_teams.push(winner_id);
+                    }
+                }
+
+                // Fill remaining spots with wild cards (best records not already in)
+                for (team_id, _record) in conf_standings.iter() {
+                    if conf_playoff_teams.len() >= playoff_teams_per_conference {
+                        break;
+                    }
+                    if !conf_playoff_teams.contains(team_id) {
+                        conf_playoff_teams.push(*team_id);
+                    }
+                }
+
+                // Add teams to conference bracket
+                for team_id in conf_playoff_teams {
+                    let team = self.teams.get(&team_id)
+                        .ok_or_else(|| format!("Team {} not found", team_id))?;
+                    let short_name = team.short_name();
+                    self.playoffs.add_team(team_id, short_name, Some(conf_index))?;
+                }
+            }
+        } else {
+            // Single-bracket path
+            let num_playoff_teams = options.num_playoff_teams;
+
+            // Validate the number of playoff teams
+            if num_playoff_teams < 2 {
+                return Err(format!("Playoffs must have at least 2 teams, got {}", num_playoff_teams));
+            }
+            if num_playoff_teams > self.teams.len() {
+                return Err(format!(
+                    "Cannot have more playoff teams ({}) than season teams ({})",
+                    num_playoff_teams, self.teams.len()
+                ));
+            }
+
+            // Get the standings and select the top teams
+            let standings = self.standings();
+
+            // Add the top teams to the playoffs in seed order
+            for (i, (team_id, _)) in standings.iter().enumerate() {
+                if i >= num_playoff_teams {
+                    break;
+                }
+
+                // Get the team's short name for the playoff bracket
+                let team = match self.teams.get(team_id) {
+                    Some(t) => t,
+                    None => return Err(format!("Team {} not found in season", team_id))
+                };
+                let short_name = team.short_name();
+
+                // Add the team to the playoffs
+                self.playoffs.add_team(*team_id, short_name, None)?;
+            }
         }
 
-        // Generate the first round (or wild card round if not a power of 2)
-        self.playoffs.gen_next_round(rng)?;
+        // Generate the first round
+        self.playoffs.gen_next_playoff_round(rng)?;
         Ok(())
     }
 
@@ -1150,6 +2281,7 @@ impl LeagueSeason {
     /// use fbsim_core::team::FootballTeam;
     /// use fbsim_core::league::season::LeagueSeason;
     /// use fbsim_core::league::season::LeagueSeasonScheduleOptions;
+    /// use fbsim_core::league::season::LeagueSeasonPlayoffOptions;
     ///
     /// // Create a new season
     /// let mut my_league_season = LeagueSeason::new();
@@ -1167,45 +2299,62 @@ impl LeagueSeason {
     /// // Simulate the entire regular season
     /// my_league_season.sim_regular_season(&mut rng);
     ///
-    /// // Generate playoffs with 4 teams
-    /// let res = my_league_season.generate_playoffs(4, &mut rng);
+    /// // Generate playoffs with 4 teams, simulate the first round
+    /// let mut playoff_options = LeagueSeasonPlayoffOptions::new();
+    /// playoff_options.num_playoff_teams = 4;
+    /// let _ = my_league_season.generate_playoffs(playoff_options, &mut rng);
+    /// let _ = my_league_season.sim_playoff_round(0, &mut rng);
+    ///
+    /// // Generate the next round of the playoffs
+    /// let res = my_league_season.generate_next_playoff_round(&mut rng);
     /// assert!(res.is_ok());
     /// ```
     pub fn generate_next_playoff_round(&mut self, rng: &mut impl Rng) -> Result<(), String> {
-        // Ensure the regular season is complete
+        // Ensure the playoffs have started, are set up, are not complete
         if !self.regular_season_complete() {
             return Err(String::from("Cannot generate playoff round: Regular season is not complete"));
         }
-
-        // Ensure the playoffs have started (teams have been added)
         if self.playoffs.num_teams() < 2 {
             return Err(String::from("Cannot generate playoff round: Playoffs have not been initialized"));
         }
-
-        // Ensure the playoffs are not already complete
         if self.playoffs.complete() {
             return Err(String::from("Cannot generate playoff round: Playoffs are already complete"));
         }
 
-        // Ensure the current round is complete before generating the next
-        if let Some(current_round) = self.playoffs.rounds().last() {
-            if !current_round.complete() {
-                return Err(String::from("Cannot generate playoff round: Current round is not complete"));
+        // Ensure all current rounds across all conference brackets are complete
+        for conference_rounds in self.playoffs.conference_brackets().values() {
+            if let Some(current_round) = conference_rounds.last() {
+                if !current_round.complete() {
+                    return Err(String::from("Cannot generate next round: Current round is not complete"));
+                }
+            }
+        }
+
+        // Ensure the current winners bracket round is complete
+        if self.playoffs.is_conference_playoff() && self.playoffs.conference_brackets_complete() {
+            if let Some(round) = self.playoffs.winners_bracket().last() {
+                if !round.complete() {
+                    return Err(
+                        String::from(
+                            "Cannot generate next round: Current winners bracket round is not complete"
+                        )
+                    )
+                }
             }
         }
 
         // Generate the next round
-        self.playoffs.gen_next_round(rng)?;
-        Ok(())
+        self.playoffs.gen_next_playoff_round(rng)
     }
 
-    /// Simulate a playoff matchup
+    /// Simulate a playoff matchup in a specific conference bracket
     ///
     /// ### Example
     /// ```
     /// use fbsim_core::team::FootballTeam;
     /// use fbsim_core::league::season::LeagueSeason;
     /// use fbsim_core::league::season::LeagueSeasonScheduleOptions;
+    /// use fbsim_core::league::season::LeagueSeasonPlayoffOptions;
     ///
     /// // Create a new season
     /// let mut my_league_season = LeagueSeason::new();
@@ -1224,26 +2373,30 @@ impl LeagueSeason {
     /// my_league_season.sim_regular_season(&mut rng);
     ///
     /// // Generate playoffs with 4 teams
-    /// my_league_season.generate_playoffs(4, &mut rng);
+    /// let mut playoff_options = LeagueSeasonPlayoffOptions::new();
+    /// playoff_options.num_playoff_teams = 4;
+    /// my_league_season.generate_playoffs(playoff_options, &mut rng);
     ///
-    /// // Simulate the first playoff matchup
-    /// let res = my_league_season.sim_playoff_matchup(0, 0, &mut rng);
+    /// // Simulate the first playoff matchup in conference bracket 0
+    /// let res = my_league_season.sim_playoff_matchup(0, 0, 0, &mut rng);
     /// assert!(res.is_ok());
     /// ```
-    pub fn sim_playoff_matchup(&mut self, round: usize, matchup: usize, rng: &mut impl Rng) -> Result<Game, String> {
+    pub fn sim_playoff_matchup(&mut self, conference: usize, round: usize, matchup: usize, rng: &mut impl Rng) -> Result<Game, String> {
         // Ensure the regular season is complete
         if !self.regular_season_complete() {
             return Err(String::from("Cannot simulate playoff matchup: Regular season is not complete"));
         }
 
         // Ensure the playoffs have started
-        if self.playoffs.rounds().is_empty() {
+        let bracket = self.playoffs.conference_bracket(conference)
+            .ok_or_else(|| format!("Cannot simulate playoff matchup: Conference bracket {} not found", conference))?;
+        if bracket.is_empty() {
             return Err(String::from("Cannot simulate playoff matchup: Playoffs have not been generated"));
         }
 
         // Check if the prior round is complete (if not the first round)
         if round > 0 {
-            let prev_round = match self.playoffs.rounds().get(round - 1) {
+            let prev_round = match bracket.get(round - 1) {
                 Some(r) => r,
                 None => return Err(format!("Failed to get previous playoff round {}", round - 1))
             };
@@ -1256,7 +2409,8 @@ impl LeagueSeason {
         }
 
         // Get the playoff round
-        let playoff_round = match self.playoffs.rounds_mut().get_mut(round) {
+        let playoff_round = match self.playoffs.conference_bracket_mut(conference)
+            .and_then(|b| b.get_mut(round)) {
             Some(r) => r,
             None => return Err(format!("No such playoff round: {}", round))
         };
@@ -1304,13 +2458,297 @@ impl LeagueSeason {
         Ok(game)
     }
 
-    /// Simulate a single play of a playoff matchup
+    /// Simulate a winners bracket matchup
     ///
     /// ### Example
     /// ```
     /// use fbsim_core::team::FootballTeam;
     /// use fbsim_core::league::season::LeagueSeason;
     /// use fbsim_core::league::season::LeagueSeasonScheduleOptions;
+    /// use fbsim_core::league::season::LeagueSeasonPlayoffOptions;
+    /// use fbsim_core::league::season::conference::{LeagueConference, LeagueDivision};
+    ///
+    /// // Create a new season with 2 conferences
+    /// let mut my_league_season = LeagueSeason::new();
+    ///
+    /// // Add teams
+    /// my_league_season.add_team(0, FootballTeam::new());
+    /// my_league_season.add_team(1, FootballTeam::new());
+    /// my_league_season.add_team(2, FootballTeam::new());
+    /// my_league_season.add_team(3, FootballTeam::new());
+    ///
+    /// // Create conference structure
+    /// let mut afc = LeagueConference::with_name("AFC");
+    /// let mut afc_div = LeagueDivision::with_name("East");
+    /// afc_div.add_team(0);
+    /// afc_div.add_team(1);
+    /// afc.add_division(afc_div);
+    /// my_league_season.add_conference(afc);
+    ///
+    /// let mut nfc = LeagueConference::with_name("NFC");
+    /// let mut nfc_div = LeagueDivision::with_name("East");
+    /// nfc_div.add_team(2);
+    /// nfc_div.add_team(3);
+    /// nfc.add_division(nfc_div);
+    /// my_league_season.add_conference(nfc);
+    ///
+    /// // Generate schedule and simulate regular season
+    /// let mut rng = rand::thread_rng();
+    /// my_league_season.generate_schedule(LeagueSeasonScheduleOptions::new(), &mut rng);
+    /// my_league_season.sim_regular_season(&mut rng);
+    ///
+    /// // Generate conference playoffs and simulate all conference brackets
+    /// let mut options = LeagueSeasonPlayoffOptions::new();
+    /// options.use_conference_brackets = true;
+    /// options.playoff_teams_per_conference = 2;
+    /// options.division_winners_guaranteed = true;
+    /// let _ = my_league_season.generate_playoffs(options, &mut rng);
+    /// let _ = my_league_season.sim_playoff_round(0, &mut rng);
+    ///
+    /// // Generate the winners bracket
+    /// let _ = my_league_season.generate_next_playoff_round(&mut rng);
+    ///
+    /// // Simulate the first winners bracket matchup
+    /// let res = my_league_season.sim_winners_bracket_matchup(0, 0, &mut rng);
+    /// assert!(res.is_ok());
+    /// ```
+    pub fn sim_winners_bracket_matchup(&mut self, round: usize, matchup: usize, rng: &mut impl Rng) -> Result<Game, String> {
+        // Ensure the regular season is complete
+        if !self.regular_season_complete() {
+            return Err(String::from("Cannot simulate winners bracket matchup: Regular season is not complete"));
+        }
+
+        // Ensure this is a conference playoff with a winners bracket
+        if !self.playoffs.is_conference_playoff() {
+            return Err(String::from("Cannot simulate winners bracket: Not a conference playoff"));
+        }
+
+        // Ensure the winners bracket has started
+        if self.playoffs.winners_bracket().is_empty() {
+            return Err(String::from("Cannot simulate winners bracket matchup: Winners bracket has not been generated"));
+        }
+
+        // Check if the prior round is complete (if not the first round)
+        if round > 0 {
+            let prev_round = match self.playoffs.winners_bracket().get(round - 1) {
+                Some(r) => r,
+                None => return Err(format!("Failed to get previous winners bracket round {}", round - 1))
+            };
+            if !prev_round.complete() {
+                return Err(format!(
+                    "Cannot simulate winners bracket round {}: Previous round {} is not complete",
+                    round, round - 1
+                ));
+            }
+        }
+
+        // Get the round
+        let playoff_round = match self.playoffs.winners_bracket_mut().get_mut(round) {
+            Some(r) => r,
+            None => return Err(format!("No such winners bracket round: {}", round))
+        };
+
+        // Get the matchup
+        let playoff_matchup = match playoff_round.matchups_mut().get_mut(matchup) {
+            Some(m) => m,
+            None => return Err(format!("No such matchup {} in winners bracket round {}", matchup, round))
+        };
+
+        // Ensure the matchup is not already complete
+        if playoff_matchup.context().game_over() {
+            return Err(format!("Winners bracket round {} matchup {} is already complete", round, matchup));
+        }
+
+        // Get the home and away teams
+        let home_id = *playoff_matchup.home_team();
+        let away_id = *playoff_matchup.away_team();
+
+        let home_team = match self.teams.get(&home_id) {
+            Some(t) => t,
+            None => return Err(format!("Winners bracket matchup references nonexistent home team ID: {}", home_id))
+        };
+        let away_team = match self.teams.get(&away_id) {
+            Some(t) => t,
+            None => return Err(format!("Winners bracket matchup references nonexistent away team ID: {}", away_id))
+        };
+
+        // Simulate the matchup
+        let mut game = Game::new();
+        let simulator = GameSimulator::new();
+        let context = match simulator.sim_game(
+            home_team, away_team,
+            playoff_matchup.context().clone(),
+            &mut game, rng
+        ) {
+            Ok(c) => c,
+            Err(e) => return Err(format!("Error while simulating winners bracket matchup: {}", e))
+        };
+
+        // Update the matchup context and stats
+        *playoff_matchup.context_mut() = context;
+        *playoff_matchup.home_stats_mut() = Some(game.home_stats());
+        *playoff_matchup.away_stats_mut() = Some(game.away_stats());
+        Ok(game)
+    }
+
+    /// Simulate a single play of a winners bracket playoff matchup
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::FootballTeam;
+    /// use fbsim_core::league::season::LeagueSeason;
+    /// use fbsim_core::league::season::LeagueSeasonScheduleOptions;
+    /// use fbsim_core::league::season::LeagueSeasonPlayoffOptions;
+    /// use fbsim_core::league::season::conference::{LeagueConference, LeagueDivision};
+    ///
+    /// // Create a new season with 2 conferences
+    /// let mut my_league_season = LeagueSeason::new();
+    ///
+    /// // Add teams
+    /// my_league_season.add_team(0, FootballTeam::new());
+    /// my_league_season.add_team(1, FootballTeam::new());
+    /// my_league_season.add_team(2, FootballTeam::new());
+    /// my_league_season.add_team(3, FootballTeam::new());
+    ///
+    /// // Create conference structure
+    /// let mut afc = LeagueConference::with_name("AFC");
+    /// let mut afc_div = LeagueDivision::with_name("East");
+    /// afc_div.add_team(0);
+    /// afc_div.add_team(1);
+    /// afc.add_division(afc_div);
+    /// my_league_season.add_conference(afc);
+    ///
+    /// let mut nfc = LeagueConference::with_name("NFC");
+    /// let mut nfc_div = LeagueDivision::with_name("East");
+    /// nfc_div.add_team(2);
+    /// nfc_div.add_team(3);
+    /// nfc.add_division(nfc_div);
+    /// my_league_season.add_conference(nfc);
+    ///
+    /// // Generate schedule and simulate regular season
+    /// let mut rng = rand::thread_rng();
+    /// my_league_season.generate_schedule(LeagueSeasonScheduleOptions::new(), &mut rng);
+    /// my_league_season.sim_regular_season(&mut rng);
+    ///
+    /// // Generate conference playoffs and simulate all conference brackets
+    /// let mut options = LeagueSeasonPlayoffOptions::new();
+    /// options.use_conference_brackets = true;
+    /// options.playoff_teams_per_conference = 2;
+    /// options.division_winners_guaranteed = true;
+    /// let _ = my_league_season.generate_playoffs(options, &mut rng);
+    /// let _ = my_league_season.sim_playoff_round(0, &mut rng);
+    ///
+    /// // Generate the winners bracket
+    /// let _ = my_league_season.generate_next_playoff_round(&mut rng);
+    ///
+    /// // Simulate a single play of the first winners bracket matchup
+    /// let res = my_league_season.sim_winners_bracket_play(0, 0, &mut rng);
+    /// assert!(res.is_ok());
+    /// ```
+    pub fn sim_winners_bracket_play(&mut self, round: usize, matchup: usize, rng: &mut impl Rng) -> Result<Option<Game>, String> {
+        // Ensure the regular season is complete
+        if !self.regular_season_complete() {
+            return Err(String::from("Cannot simulate winners bracket play: Regular season is not complete"));
+        }
+
+        // Ensure this is a conference playoff with a winners bracket
+        if !self.playoffs.is_conference_playoff() {
+            return Err(String::from("Cannot simulate winners bracket: Not a conference playoff"));
+        }
+
+        // Ensure the winners bracket has started
+        if self.playoffs.winners_bracket().is_empty() {
+            return Err(String::from("Cannot simulate winners bracket play: Winners bracket has not been generated"));
+        }
+
+        // Check if the prior round is complete (if not the first round)
+        if round > 0 {
+            let prev_round = match self.playoffs.winners_bracket().get(round - 1) {
+                Some(r) => r,
+                None => return Err(format!("Failed to get previous winners bracket round {}", round - 1))
+            };
+            if !prev_round.complete() {
+                return Err(format!(
+                    "Cannot simulate winners bracket round {}: Previous round {} is not complete",
+                    round, round - 1
+                ));
+            }
+        }
+
+        // Get the round
+        let playoff_round = match self.playoffs.winners_bracket_mut().get_mut(round) {
+            Some(r) => r,
+            None => return Err(format!("No such winners bracket round: {}", round))
+        };
+
+        // Get the matchup
+        let playoff_matchup = match playoff_round.matchups_mut().get_mut(matchup) {
+            Some(m) => m,
+            None => return Err(format!("No such matchup {} in winners bracket round {}", matchup, round))
+        };
+
+        // Ensure the matchup is not already complete
+        if playoff_matchup.context().game_over() {
+            return Err(format!("Winners bracket round {} matchup {} is already complete", round, matchup));
+        }
+
+        // Get the home and away teams
+        let home_id = *playoff_matchup.home_team();
+        let away_id = *playoff_matchup.away_team();
+
+        let home_team = match self.teams.get(&home_id) {
+            Some(t) => t,
+            None => return Err(format!("Winners bracket matchup references nonexistent home team ID: {}", home_id))
+        };
+        let away_team = match self.teams.get(&away_id) {
+            Some(t) => t,
+            None => return Err(format!("Winners bracket matchup references nonexistent away team ID: {}", away_id))
+        };
+
+        // Create a new game if game has not started, or get existing game
+        if playoff_matchup.game().is_none() {
+            *playoff_matchup.game_mut() = Some(Game::new());
+        }
+
+        // Simulate the next play
+        let simulator = GameSimulator::new();
+        let context = match simulator.sim_play(
+            home_team, away_team,
+            playoff_matchup.context().clone(),
+            playoff_matchup.game_mut().as_mut().unwrap(),
+            rng
+        ) {
+            Ok(c) => c,
+            Err(e) => return Err(format!("Error while simulating winners bracket play: {}", e))
+        };
+
+        // If game is over, archive game stats, clear game, update context
+        if context.game_over() {
+            *playoff_matchup.home_stats_mut() = Some(
+                playoff_matchup.game().as_ref().ok_or(
+                    "Failed to archive home stats for winners bracket game"
+                )?.home_stats()
+            );
+            *playoff_matchup.away_stats_mut() = Some(
+                playoff_matchup.game().as_ref().ok_or(
+                    "Failed to archive away stats for winners bracket game"
+                )?.away_stats()
+            );
+            *playoff_matchup.context_mut() = context;
+            return Ok(playoff_matchup.take_game());
+        }
+        *playoff_matchup.context_mut() = context;
+        Ok(None)
+    }
+
+    /// Simulate a single play of a playoff matchup in a specific conference bracket
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::FootballTeam;
+    /// use fbsim_core::league::season::LeagueSeason;
+    /// use fbsim_core::league::season::LeagueSeasonScheduleOptions;
+    /// use fbsim_core::league::season::LeagueSeasonPlayoffOptions;
     ///
     /// // Create a new season
     /// let mut my_league_season = LeagueSeason::new();
@@ -1329,26 +2767,30 @@ impl LeagueSeason {
     /// my_league_season.sim_regular_season(&mut rng);
     ///
     /// // Generate playoffs with 4 teams
-    /// my_league_season.generate_playoffs(4, &mut rng);
+    /// let mut playoff_options = LeagueSeasonPlayoffOptions::new();
+    /// playoff_options.num_playoff_teams = 4;
+    /// my_league_season.generate_playoffs(playoff_options, &mut rng);
     ///
     /// // Simulate a single play of the first playoff matchup
-    /// let res = my_league_season.sim_playoff_play(0, 0, &mut rng);
+    /// let res = my_league_season.sim_playoff_play(0, 0, 0, &mut rng);
     /// assert!(res.is_ok());
     /// ```
-    pub fn sim_playoff_play(&mut self, round: usize, matchup: usize, rng: &mut impl Rng) -> Result<Option<Game>, String> {
+    pub fn sim_playoff_play(&mut self, conference: usize, round: usize, matchup: usize, rng: &mut impl Rng) -> Result<Option<Game>, String> {
         // Ensure the regular season is complete
         if !self.regular_season_complete() {
             return Err(String::from("Cannot simulate playoff play: Regular season is not complete"));
         }
 
         // Ensure the playoffs have started
-        if self.playoffs.rounds().is_empty() {
+        let bracket = self.playoffs.conference_bracket(conference)
+            .ok_or_else(|| format!("Cannot simulate playoff play: Conference bracket {} not found", conference))?;
+        if bracket.is_empty() {
             return Err(String::from("Cannot simulate playoff play: Playoffs have not been generated"));
         }
 
         // Check if the prior round is complete (if not the first round)
         if round > 0 {
-            let prev_round = match self.playoffs.rounds().get(round - 1) {
+            let prev_round = match bracket.get(round - 1) {
                 Some(r) => r,
                 None => return Err(format!("Failed to get previous playoff round {}", round - 1))
             };
@@ -1361,7 +2803,8 @@ impl LeagueSeason {
         }
 
         // Get the playoff round
-        let playoff_round = match self.playoffs.rounds_mut().get_mut(round) {
+        let playoff_round = match self.playoffs.conference_bracket_mut(conference)
+            .and_then(|b| b.get_mut(round)) {
             Some(r) => r,
             None => return Err(format!("No such playoff round: {}", round))
         };
@@ -1426,13 +2869,14 @@ impl LeagueSeason {
         Ok(None)
     }
 
-    /// Simulate a full playoff round
+    /// Simulate all matchups in a specific conference bracket round
     ///
     /// ### Example
     /// ```
     /// use fbsim_core::team::FootballTeam;
     /// use fbsim_core::league::season::LeagueSeason;
     /// use fbsim_core::league::season::LeagueSeasonScheduleOptions;
+    /// use fbsim_core::league::season::LeagueSeasonPlayoffOptions;
     ///
     /// // Create a new season
     /// let mut my_league_season = LeagueSeason::new();
@@ -1451,26 +2895,30 @@ impl LeagueSeason {
     /// my_league_season.sim_regular_season(&mut rng);
     ///
     /// // Generate playoffs with 4 teams
-    /// my_league_season.generate_playoffs(4, &mut rng);
+    /// let mut playoff_options = LeagueSeasonPlayoffOptions::new();
+    /// playoff_options.num_playoff_teams = 4;
+    /// my_league_season.generate_playoffs(playoff_options, &mut rng);
     ///
-    /// // Simulate the first playoff round
-    /// let res = my_league_season.sim_playoff_round(0, &mut rng);
+    /// // Simulate the first round of conference bracket 0
+    /// let res = my_league_season.sim_playoff_conference_round(0, 0, &mut rng);
     /// assert!(res.is_ok());
     /// ```
-    pub fn sim_playoff_round(&mut self, round: usize, rng: &mut impl Rng) -> Result<(), String> {
+    pub fn sim_playoff_conference_round(&mut self, conference: usize, round: usize, rng: &mut impl Rng) -> Result<(), String> {
         // Ensure the regular season is complete
         if !self.regular_season_complete() {
             return Err(String::from("Cannot simulate playoff round: Regular season is not complete"));
         }
 
-        // Ensure the playoffs have started
-        if self.playoffs.rounds().is_empty() {
+        // Ensure the bracket exists
+        let bracket = self.playoffs.conference_bracket(conference)
+            .ok_or_else(|| format!("Cannot simulate playoff round: Conference bracket {} not found", conference))?;
+        if bracket.is_empty() {
             return Err(String::from("Cannot simulate playoff round: Playoffs have not been generated"));
         }
 
         // Check if the prior round is complete (if not the first round)
         if round > 0 {
-            let prev_round = match self.playoffs.rounds().get(round - 1) {
+            let prev_round = match bracket.get(round - 1) {
                 Some(r) => r,
                 None => return Err(format!("Failed to get previous playoff round {}", round - 1))
             };
@@ -1483,7 +2931,7 @@ impl LeagueSeason {
         }
 
         // Get the number of matchups in this round
-        let num_matchups = match self.playoffs.rounds().get(round) {
+        let num_matchups = match bracket.get(round) {
             Some(r) => r.matchups().len(),
             None => return Err(format!("No such playoff round: {}", round))
         };
@@ -1491,7 +2939,8 @@ impl LeagueSeason {
         // Simulate each matchup in the round
         for i in 0..num_matchups {
             // Skip matchups that have already been completed
-            let is_complete = match self.playoffs.rounds().get(round) {
+            let is_complete = match self.playoffs.conference_bracket(conference)
+                .and_then(|b| b.get(round)) {
                 Some(r) => match r.matchups().get(i) {
                     Some(m) => m.context().game_over(),
                     None => continue
@@ -1503,18 +2952,129 @@ impl LeagueSeason {
             }
 
             // Simulate the matchup
-            self.sim_playoff_matchup(round, i, rng)?;
+            self.sim_playoff_matchup(conference, round, i, rng)?;
         }
         Ok(())
     }
 
-    /// Simulate all remaining playoffs
+    /// Simulate a winners bracket round
     ///
     /// ### Example
     /// ```
     /// use fbsim_core::team::FootballTeam;
     /// use fbsim_core::league::season::LeagueSeason;
     /// use fbsim_core::league::season::LeagueSeasonScheduleOptions;
+    /// use fbsim_core::league::season::LeagueSeasonPlayoffOptions;
+    /// use fbsim_core::league::season::conference::{LeagueConference, LeagueDivision};
+    ///
+    /// // Create a new season with 2 conferences
+    /// let mut my_league_season = LeagueSeason::new();
+    ///
+    /// // Add teams
+    /// my_league_season.add_team(0, FootballTeam::new());
+    /// my_league_season.add_team(1, FootballTeam::new());
+    /// my_league_season.add_team(2, FootballTeam::new());
+    /// my_league_season.add_team(3, FootballTeam::new());
+    ///
+    /// // Create conference structure
+    /// let mut afc = LeagueConference::with_name("AFC");
+    /// let mut afc_div = LeagueDivision::with_name("East");
+    /// afc_div.add_team(0);
+    /// afc_div.add_team(1);
+    /// afc.add_division(afc_div);
+    /// my_league_season.add_conference(afc);
+    ///
+    /// let mut nfc = LeagueConference::with_name("NFC");
+    /// let mut nfc_div = LeagueDivision::with_name("East");
+    /// nfc_div.add_team(2);
+    /// nfc_div.add_team(3);
+    /// nfc.add_division(nfc_div);
+    /// my_league_season.add_conference(nfc);
+    ///
+    /// // Generate schedule and simulate regular season
+    /// let mut rng = rand::thread_rng();
+    /// my_league_season.generate_schedule(LeagueSeasonScheduleOptions::new(), &mut rng);
+    /// my_league_season.sim_regular_season(&mut rng);
+    ///
+    /// // Generate conference playoffs and simulate all conference brackets
+    /// let mut options = LeagueSeasonPlayoffOptions::new();
+    /// options.use_conference_brackets = true;
+    /// options.playoff_teams_per_conference = 2;
+    /// options.division_winners_guaranteed = true;
+    /// let _ = my_league_season.generate_playoffs(options, &mut rng);
+    /// let _ = my_league_season.sim_playoff_round(0, &mut rng);
+    ///
+    /// // Generate the winners bracket
+    /// let _ = my_league_season.generate_next_playoff_round(&mut rng);
+    ///
+    /// // Simulate the first winners bracket round
+    /// let res = my_league_season.sim_winners_bracket_round(0, &mut rng);
+    /// assert!(res.is_ok());
+    /// ```
+    pub fn sim_winners_bracket_round(&mut self, round: usize, rng: &mut impl Rng) -> Result<(), String> {
+        // Ensure the regular season is complete
+        if !self.regular_season_complete() {
+            return Err(String::from("Cannot simulate winners bracket round: Regular season is not complete"));
+        }
+
+        // Ensure this is a conference playoff
+        if !self.playoffs.is_conference_playoff() {
+            return Err(String::from("Cannot simulate winners bracket: Not a conference playoff"));
+        }
+
+        // Ensure the winners bracket has started
+        if self.playoffs.winners_bracket().is_empty() {
+            return Err(String::from("Cannot simulate winners bracket round: Winners bracket has not been generated"));
+        }
+
+        // Check if the prior round is complete (if not the first round)
+        if round > 0 {
+            let prev_round = match self.playoffs.winners_bracket().get(round - 1) {
+                Some(r) => r,
+                None => return Err(format!("Failed to get previous winners bracket round {}", round - 1))
+            };
+            if !prev_round.complete() {
+                return Err(format!(
+                    "Cannot simulate winners bracket round {}: Previous round {} is not complete",
+                    round, round - 1
+                ));
+            }
+        }
+
+        // Get the number of matchups in this round
+        let num_matchups = match self.playoffs.winners_bracket().get(round) {
+            Some(r) => r.matchups().len(),
+            None => return Err(format!("No such winners bracket round: {}", round))
+        };
+
+        // Simulate each matchup in the round
+        for i in 0..num_matchups {
+            // Skip matchups that have already been completed
+            let is_complete = match self.playoffs.winners_bracket().get(round) {
+                Some(r) => match r.matchups().get(i) {
+                    Some(m) => m.context().game_over(),
+                    None => continue
+                },
+                None => continue
+            };
+            if is_complete {
+                continue;
+            }
+
+            // Simulate the matchup
+            self.sim_winners_bracket_matchup(round, i, rng)?;
+        }
+        Ok(())
+    }
+
+    /// Simulate a full playoff round across all conference brackets
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::FootballTeam;
+    /// use fbsim_core::league::season::LeagueSeason;
+    /// use fbsim_core::league::season::LeagueSeasonScheduleOptions;
+    /// use fbsim_core::league::season::LeagueSeasonPlayoffOptions;
     ///
     /// // Create a new season
     /// let mut my_league_season = LeagueSeason::new();
@@ -1533,7 +3093,77 @@ impl LeagueSeason {
     /// my_league_season.sim_regular_season(&mut rng);
     ///
     /// // Generate playoffs with 4 teams
-    /// my_league_season.generate_playoffs(4, &mut rng);
+    /// let mut playoff_options = LeagueSeasonPlayoffOptions::new();
+    /// playoff_options.num_playoff_teams = 4;
+    /// my_league_season.generate_playoffs(playoff_options, &mut rng);
+    ///
+    /// // Simulate the first playoff round
+    /// let res = my_league_season.sim_playoff_round(0, &mut rng);
+    /// assert!(res.is_ok());
+    /// ```
+    pub fn sim_playoff_round(&mut self, round: usize, rng: &mut impl Rng) -> Result<(), String> {
+        // Ensure the regular season is complete
+        if !self.regular_season_complete() {
+            return Err(String::from("Cannot simulate playoff round: Regular season is not complete"));
+        }
+
+        // Ensure the playoffs have started
+        if self.playoffs.conference_brackets().is_empty() {
+            return Err(String::from("Cannot simulate playoff round: Playoffs have not been generated"));
+        }
+
+        // Simulate the round in each conference bracket
+        let conference_ids: Vec<usize> = self.playoffs.conference_brackets().keys().copied().collect();
+        for conf_id in conference_ids {
+            // Skip conferences that don't have this round
+            let has_round = self.playoffs.conference_bracket(conf_id)
+                .is_some_and(|b| b.len() > round);
+            if !has_round {
+                continue;
+            }
+
+            // Skip conferences whose round is already complete
+            let round_complete = self.playoffs.conference_bracket(conf_id)
+                .and_then(|b| b.get(round))
+                .is_some_and(|r| r.complete());
+            if round_complete {
+                continue;
+            }
+
+            self.sim_playoff_conference_round(conf_id, round, rng)?;
+        }
+        Ok(())
+    }
+
+    /// Simulate all remaining playoffs
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::team::FootballTeam;
+    /// use fbsim_core::league::season::LeagueSeason;
+    /// use fbsim_core::league::season::LeagueSeasonScheduleOptions;
+    /// use fbsim_core::league::season::LeagueSeasonPlayoffOptions;
+    ///
+    /// // Create a new season
+    /// let mut my_league_season = LeagueSeason::new();
+    ///
+    /// // Add 4 teams to the season
+    /// my_league_season.add_team(0, FootballTeam::new());
+    /// my_league_season.add_team(1, FootballTeam::new());
+    /// my_league_season.add_team(2, FootballTeam::new());
+    /// my_league_season.add_team(3, FootballTeam::new());
+    ///
+    /// // Generate the season schedule
+    /// let mut rng = rand::thread_rng();
+    /// my_league_season.generate_schedule(LeagueSeasonScheduleOptions::new(), &mut rng);
+    ///
+    /// // Simulate the entire regular season
+    /// my_league_season.sim_regular_season(&mut rng);
+    ///
+    /// // Generate playoffs with 4 teams
+    /// let mut playoff_options = LeagueSeasonPlayoffOptions::new();
+    /// playoff_options.num_playoff_teams = 4;
+    /// my_league_season.generate_playoffs(playoff_options, &mut rng);
     ///
     /// // Simulate all playoffs
     /// let res = my_league_season.sim_playoffs(&mut rng);
@@ -1546,23 +3176,37 @@ impl LeagueSeason {
         }
 
         // Ensure the playoffs have started
-        if self.playoffs.rounds().is_empty() {
+        if self.playoffs.conference_brackets().is_empty() {
             return Err(String::from("Cannot simulate playoffs: playoffs have not been generated"));
         }
 
         // Simulate rounds until playoffs are complete
         while !self.playoffs.complete() {
-            // Get the current round index
-            let current_round = self.playoffs.rounds().len() - 1;
+            // If conference brackets are not yet complete, simulate them
+            if !self.playoffs.conference_brackets_complete() {
+                // Get the current round index (minimum across all brackets)
+                let current_round = self.playoffs
+                    .conference_brackets().values().map(|b| b.len().saturating_sub(1))
+                    .min()
+                    .unwrap_or_default();
 
-            // Simulate the current round if not complete
-            if !self.playoffs.rounds().get(current_round).is_none_or(|r| r.complete()) {
+                // Simulate the current round across all conferences
                 self.sim_playoff_round(current_round, rng)?;
-            }
 
-            // Generate the next round if the current round is complete and playoffs aren't done
-            if !self.playoffs.complete() {
-                self.generate_next_playoff_round(rng)?;
+                // Generate the next round if needed and playoffs aren't done
+                if !self.playoffs.complete() {
+                    self.generate_next_playoff_round(rng)?;
+                }
+            } else if self.playoffs.is_conference_playoff() {
+                // Conference brackets complete, simulate winners bracket
+                let current_round = self.playoffs.winners_bracket().len().saturating_sub(1);
+
+                self.sim_winners_bracket_round(current_round, rng)?;
+
+                // Generate the next winners bracket round if needed
+                if !self.playoffs.complete() {
+                    self.generate_next_playoff_round(rng)?;
+                }
             }
         }
         Ok(())

--- a/src/league/season/conference.rs
+++ b/src/league/season/conference.rs
@@ -1,0 +1,663 @@
+#[cfg(feature = "rocket_okapi")]
+use rocket_okapi::okapi::schemars;
+#[cfg(feature = "rocket_okapi")]
+use rocket_okapi::okapi::schemars::JsonSchema;
+use serde::{Serialize, Deserialize, Deserializer};
+use std::collections::HashSet;
+
+/// Maximum allowed length for a division name
+const MAX_DIVISION_NAME_LEN: usize = 64;
+
+/// Maximum allowed length for a conference name
+const MAX_CONFERENCE_NAME_LEN: usize = 64;
+
+/// # `LeagueDivisionRaw` struct
+///
+/// A freshly deserialized `LeagueDivision` prior to validation.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize, Deserialize)]
+pub struct LeagueDivisionRaw {
+    pub name: String,
+    pub teams: Vec<usize>,
+}
+
+impl LeagueDivisionRaw {
+    /// Validate the raw division
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::conference::LeagueDivisionRaw;
+    ///
+    /// let raw = LeagueDivisionRaw { name: "East".to_string(), teams: vec![0, 1] };
+    /// assert!(raw.validate().is_ok());
+    /// ```
+    pub fn validate(&self) -> Result<(), String> {
+        // Validate name length
+        if self.name.len() > MAX_DIVISION_NAME_LEN {
+            return Err(format!(
+                "Division name '{}' exceeds maximum length of {} characters",
+                self.name, MAX_DIVISION_NAME_LEN
+            ));
+        }
+
+        // Check for duplicate team IDs
+        let mut seen = HashSet::new();
+        for &team_id in &self.teams {
+            if !seen.insert(team_id) {
+                return Err(format!(
+                    "Duplicate team ID {} in division '{}'",
+                    team_id, self.name
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl TryFrom<LeagueDivisionRaw> for LeagueDivision {
+    type Error = String;
+
+    fn try_from(raw: LeagueDivisionRaw) -> Result<Self, Self::Error> {
+        raw.validate()?;
+        Ok(LeagueDivision {
+            name: raw.name,
+            teams: raw.teams,
+        })
+    }
+}
+
+/// # `LeagueConferenceRaw` struct
+///
+/// A freshly deserialized `LeagueConference` prior to validation.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize, Deserialize)]
+pub struct LeagueConferenceRaw {
+    pub name: String,
+    pub divisions: Vec<LeagueDivision>,
+}
+
+impl LeagueConferenceRaw {
+    /// Validate the raw conference
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::conference::{LeagueConferenceRaw, LeagueDivision};
+    ///
+    /// let mut div = LeagueDivision::with_name("East");
+    /// div.add_team(0);
+    /// div.add_team(1);
+    /// let raw = LeagueConferenceRaw {
+    ///     name: "AFC".to_string(),
+    ///     divisions: vec![div],
+    /// };
+    /// assert!(raw.validate().is_ok());
+    /// ```
+    pub fn validate(&self) -> Result<(), String> {
+        // Validate name length
+        if self.name.len() > MAX_CONFERENCE_NAME_LEN {
+            return Err(format!(
+                "Conference name '{}' exceeds maximum length of {} characters",
+                self.name, MAX_CONFERENCE_NAME_LEN
+            ));
+        }
+
+        // Check for duplicate team IDs across divisions
+        let mut seen = HashSet::new();
+        for division in &self.divisions {
+            for &team_id in division.teams() {
+                if !seen.insert(team_id) {
+                    return Err(format!(
+                        "Duplicate team ID {} across divisions in conference '{}'",
+                        team_id, self.name
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl TryFrom<LeagueConferenceRaw> for LeagueConference {
+    type Error = String;
+
+    fn try_from(raw: LeagueConferenceRaw) -> Result<Self, Self::Error> {
+        raw.validate()?;
+        Ok(LeagueConference {
+            name: raw.name,
+            divisions: raw.divisions,
+        })
+    }
+}
+
+/// # `LeagueDivision` struct
+///
+/// A `LeagueDivision` represents a division within a conference, containing
+/// a collection of team IDs. The division ID is implicit as the key in the
+/// parent conference's `divisions` BTreeMap.
+#[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize)]
+pub struct LeagueDivision {
+    name: String,
+    teams: Vec<usize>,
+}
+
+impl Default for LeagueDivision {
+    /// Default constructor for the LeagueDivision struct
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::conference::LeagueDivision;
+    ///
+    /// let division = LeagueDivision::default();
+    /// ```
+    fn default() -> Self {
+        LeagueDivision {
+            name: String::new(),
+            teams: Vec::new(),
+        }
+    }
+}
+
+impl LeagueDivision {
+    /// Constructor for the LeagueDivision struct
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::conference::LeagueDivision;
+    ///
+    /// let division = LeagueDivision::new();
+    /// ```
+    pub fn new() -> LeagueDivision {
+        LeagueDivision::default()
+    }
+
+    /// Constructor with name
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::conference::LeagueDivision;
+    ///
+    /// let division = LeagueDivision::with_name("East");
+    /// ```
+    pub fn with_name(name: &str) -> LeagueDivision {
+        LeagueDivision {
+            name: name.to_string(),
+            teams: Vec::new(),
+        }
+    }
+
+    /// Borrow the division name
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::conference::LeagueDivision;
+    ///
+    /// let division = LeagueDivision::with_name("East");
+    /// assert_eq!(division.name(), "East");
+    /// ```
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Mutably borrow the division name
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::conference::LeagueDivision;
+    ///
+    /// let mut division = LeagueDivision::new();
+    /// *division.name_mut() = "West".to_string();
+    /// ```
+    pub fn name_mut(&mut self) -> &mut String {
+        &mut self.name
+    }
+
+    /// Borrow the teams in the division
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::conference::LeagueDivision;
+    ///
+    /// let division = LeagueDivision::new();
+    /// let teams = division.teams();
+    /// ```
+    pub fn teams(&self) -> &Vec<usize> {
+        &self.teams
+    }
+
+    /// Mutably borrow the teams in the division
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::conference::LeagueDivision;
+    ///
+    /// let mut division = LeagueDivision::new();
+    /// division.teams_mut().push(0);
+    /// ```
+    pub fn teams_mut(&mut self) -> &mut Vec<usize> {
+        &mut self.teams
+    }
+
+    /// Add a team to the division
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::conference::LeagueDivision;
+    ///
+    /// let mut division = LeagueDivision::new();
+    /// division.add_team(0).unwrap();
+    /// division.add_team(1).unwrap();
+    /// assert_eq!(division.teams().len(), 2);
+    /// ```
+    pub fn add_team(&mut self, team_id: usize) -> Result<(), String> {
+        if self.teams.contains(&team_id) {
+            return Err(format!(
+                "Team with ID {} already exists in division '{}'",
+                team_id, self.name
+            ));
+        }
+        self.teams.push(team_id);
+        Ok(())
+    }
+
+    /// Check if a team is in this division
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::conference::LeagueDivision;
+    ///
+    /// let mut division = LeagueDivision::new();
+    /// division.add_team(0);
+    /// assert!(division.contains_team(0));
+    /// assert!(!division.contains_team(1));
+    /// ```
+    pub fn contains_team(&self, team_id: usize) -> bool {
+        self.teams.contains(&team_id)
+    }
+
+    /// Get the number of teams in the division
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::conference::LeagueDivision;
+    ///
+    /// let mut division = LeagueDivision::new();
+    /// division.add_team(0);
+    /// division.add_team(1);
+    /// assert_eq!(division.num_teams(), 2);
+    /// ```
+    pub fn num_teams(&self) -> usize {
+        self.teams.len()
+    }
+}
+
+impl<'de> Deserialize<'de> for LeagueDivision {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = LeagueDivisionRaw::deserialize(deserializer)?;
+        LeagueDivision::try_from(raw).map_err(serde::de::Error::custom)
+    }
+}
+
+/// # `LeagueConference` struct
+///
+/// A `LeagueConference` represents a conference containing multiple divisions.
+/// The conference ID is implicit as the index in the parent season's
+/// `conferences` Vec.
+#[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize)]
+pub struct LeagueConference {
+    name: String,
+    divisions: Vec<LeagueDivision>,
+}
+
+impl Default for LeagueConference {
+    /// Default constructor for the LeagueConference struct
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::conference::LeagueConference;
+    ///
+    /// let conference = LeagueConference::default();
+    /// ```
+    fn default() -> Self {
+        LeagueConference {
+            name: String::new(),
+            divisions: Vec::new(),
+        }
+    }
+}
+
+impl LeagueConference {
+    /// Constructor for the LeagueConference struct
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::conference::LeagueConference;
+    ///
+    /// let conference = LeagueConference::new();
+    /// ```
+    pub fn new() -> LeagueConference {
+        LeagueConference::default()
+    }
+
+    /// Constructor with name
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::conference::LeagueConference;
+    ///
+    /// let conference = LeagueConference::with_name("AFC");
+    /// ```
+    pub fn with_name(name: &str) -> LeagueConference {
+        LeagueConference {
+            name: name.to_string(),
+            divisions: Vec::new(),
+        }
+    }
+
+    /// Borrow the conference name
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::conference::LeagueConference;
+    ///
+    /// let conference = LeagueConference::with_name("AFC");
+    /// assert_eq!(conference.name(), "AFC");
+    /// ```
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Mutably borrow the conference name
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::conference::LeagueConference;
+    ///
+    /// let mut conference = LeagueConference::new();
+    /// *conference.name_mut() = "NFC".to_string();
+    /// ```
+    pub fn name_mut(&mut self) -> &mut String {
+        &mut self.name
+    }
+
+    /// Borrow the divisions in the conference
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::conference::LeagueConference;
+    ///
+    /// let conference = LeagueConference::new();
+    /// let divisions = conference.divisions();
+    /// ```
+    pub fn divisions(&self) -> &Vec<LeagueDivision> {
+        &self.divisions
+    }
+
+    /// Mutably borrow the divisions in the conference
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::conference::LeagueConference;
+    ///
+    /// let mut conference = LeagueConference::new();
+    /// let divisions = conference.divisions_mut();
+    /// ```
+    pub fn divisions_mut(&mut self) -> &mut Vec<LeagueDivision> {
+        &mut self.divisions
+    }
+
+    /// Add a division to the conference
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::conference::{LeagueConference, LeagueDivision};
+    ///
+    /// let mut conference = LeagueConference::new();
+    /// let division = LeagueDivision::with_name("East");
+    /// conference.add_division(division);
+    /// ```
+    pub fn add_division(&mut self, division: LeagueDivision) -> Result<(), String> {
+        let existing_teams = self.all_teams();
+        for team_id in division.teams() {
+            if existing_teams.contains(team_id) {
+                return Err(format!(
+                    "Team with ID {} already exists in conference '{}'",
+                    team_id, self.name
+                ));
+            }
+        }
+        self.divisions.push(division);
+        Ok(())
+    }
+
+    /// Get a division by ID
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::conference::{LeagueConference, LeagueDivision};
+    ///
+    /// let mut conference = LeagueConference::new();
+    /// conference.add_division(LeagueDivision::with_name("East"));
+    /// let division = conference.division(0);
+    /// assert!(division.is_some());
+    /// ```
+    pub fn division(&self, id: usize) -> Option<&LeagueDivision> {
+        self.divisions.get(id)
+    }
+
+    /// Get a mutable division by ID
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::conference::{LeagueConference, LeagueDivision};
+    ///
+    /// let mut conference = LeagueConference::new();
+    /// conference.add_division(LeagueDivision::with_name("East"));
+    /// let division = conference.division_mut(0);
+    /// assert!(division.is_some());
+    /// ```
+    pub fn division_mut(&mut self, id: usize) -> Option<&mut LeagueDivision> {
+        self.divisions.get_mut(id)
+    }
+
+    /// Get all team IDs in this conference (across all divisions)
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::conference::{LeagueConference, LeagueDivision};
+    ///
+    /// let mut conference = LeagueConference::new();
+    /// let mut east = LeagueDivision::with_name("East");
+    /// east.add_team(0);
+    /// east.add_team(1);
+    /// let mut west = LeagueDivision::with_name("West");
+    /// west.add_team(2);
+    /// west.add_team(3);
+    /// conference.add_division(east);
+    /// conference.add_division(west);
+    ///
+    /// let teams = conference.all_teams();
+    /// assert_eq!(teams.len(), 4);
+    /// ```
+    pub fn all_teams(&self) -> Vec<usize> {
+        self.divisions
+            .iter()
+            .flat_map(|d| d.teams().iter().cloned())
+            .collect()
+    }
+
+    /// Check if a team is in this conference
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::conference::{LeagueConference, LeagueDivision};
+    ///
+    /// let mut conference = LeagueConference::new();
+    /// let mut division = LeagueDivision::new();
+    /// division.add_team(0);
+    /// conference.add_division(division);
+    ///
+    /// assert!(conference.contains_team(0));
+    /// assert!(!conference.contains_team(1));
+    /// ```
+    pub fn contains_team(&self, team_id: usize) -> bool {
+        self.divisions.iter().any(|d| d.contains_team(team_id))
+    }
+
+    /// Find which division a team is in (returns division ID)
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::conference::{LeagueConference, LeagueDivision};
+    ///
+    /// let mut conference = LeagueConference::new();
+    /// let mut division = LeagueDivision::new();
+    /// division.add_team(0);
+    /// conference.add_division(division);
+    ///
+    /// assert_eq!(conference.team_division(0), Some(0));
+    /// assert_eq!(conference.team_division(1), None);
+    /// ```
+    pub fn team_division(&self, team_id: usize) -> Option<usize> {
+        for (div_id, division) in self.divisions.iter().enumerate() {
+            if division.contains_team(team_id) {
+                return Some(div_id);
+            }
+        }
+        None
+    }
+
+    /// Get the number of divisions in the conference
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::conference::{LeagueConference, LeagueDivision};
+    ///
+    /// let mut conference = LeagueConference::new();
+    /// conference.add_division(LeagueDivision::new());
+    /// conference.add_division(LeagueDivision::new());
+    /// assert_eq!(conference.num_divisions(), 2);
+    /// ```
+    pub fn num_divisions(&self) -> usize {
+        self.divisions.len()
+    }
+
+    /// Get the total number of teams in the conference
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::conference::{LeagueConference, LeagueDivision};
+    ///
+    /// let mut conference = LeagueConference::new();
+    /// let mut division = LeagueDivision::new();
+    /// division.add_team(0);
+    /// division.add_team(1);
+    /// conference.add_division(division);
+    /// assert_eq!(conference.num_teams(), 2);
+    /// ```
+    pub fn num_teams(&self) -> usize {
+        self.divisions.iter().map(|d| d.num_teams()).sum()
+    }
+}
+
+impl<'de> Deserialize<'de> for LeagueConference {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = LeagueConferenceRaw::deserialize(deserializer)?;
+        LeagueConference::try_from(raw).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_division_creation() {
+        let mut division = LeagueDivision::with_name("East");
+        let _ = division.add_team(0);
+        let _ = division.add_team(1);
+        let _ = division.add_team(2);
+        let _ = division.add_team(3);
+
+        assert_eq!(division.name(), "East");
+        assert_eq!(division.num_teams(), 4);
+        assert!(division.contains_team(0));
+        assert!(division.contains_team(3));
+        assert!(!division.contains_team(4));
+    }
+
+    #[test]
+    fn test_conference_creation() {
+        let mut conference = LeagueConference::with_name("AFC");
+
+        let mut east = LeagueDivision::with_name("East");
+        let _ = east.add_team(0);
+        let _ = east.add_team(1);
+
+        let mut west = LeagueDivision::with_name("West");
+        let _ = west.add_team(2);
+        let _ = west.add_team(3);
+
+        let _ = conference.add_division(east);
+        let _ = conference.add_division(west);
+
+        assert_eq!(conference.name(), "AFC");
+        assert_eq!(conference.num_divisions(), 2);
+        assert_eq!(conference.num_teams(), 4);
+        assert!(conference.contains_team(0));
+        assert!(conference.contains_team(3));
+        assert!(!conference.contains_team(4));
+    }
+
+    #[test]
+    fn test_team_division_lookup() {
+        let mut conference = LeagueConference::new();
+
+        let mut east = LeagueDivision::new();
+        let _ = east.add_team(0);
+        let _ = east.add_team(1);
+
+        let mut west = LeagueDivision::new();
+        let _ = west.add_team(2);
+        let _ = west.add_team(3);
+
+        let _ = conference.add_division(east);
+        let _ = conference.add_division(west);
+
+        assert_eq!(conference.team_division(0), Some(0));
+        assert_eq!(conference.team_division(1), Some(0));
+        assert_eq!(conference.team_division(2), Some(1));
+        assert_eq!(conference.team_division(3), Some(1));
+        assert_eq!(conference.team_division(4), None);
+    }
+
+    #[test]
+    fn test_all_teams() {
+        let mut conference = LeagueConference::new();
+
+        let mut div1 = LeagueDivision::new();
+        let _ = div1.add_team(0);
+        let _ = div1.add_team(1);
+
+        let mut div2 = LeagueDivision::new();
+        let _ = div2.add_team(2);
+        let _ = div2.add_team(3);
+
+        let _ = conference.add_division(div1);
+        let _ = conference.add_division(div2);
+
+        let teams = conference.all_teams();
+        assert_eq!(teams.len(), 4);
+        assert!(teams.contains(&0));
+        assert!(teams.contains(&1));
+        assert!(teams.contains(&2));
+        assert!(teams.contains(&3));
+    }
+}

--- a/src/league/season/matchup.rs
+++ b/src/league/season/matchup.rs
@@ -317,6 +317,34 @@ impl LeagueSeasonMatchup {
     }
 }
 
+impl std::fmt::Display for LeagueSeasonMatchup {
+    /// Format a `LeagueSeasonMatchup` as a string.
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::matchup::LeagueSeasonMatchup;
+    ///
+    /// let mut rng = rand::thread_rng();
+    /// let my_matchup = LeagueSeasonMatchup::new(0, 1, "HOME", "AWAY", &mut rng);
+    /// println!("{}", my_matchup);
+    /// ```
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let desc = if self.context.game_over() {
+            "Game over"
+        } else if self.context.started() {
+            "In progress"
+        } else {
+            "Pending"
+        };
+        let matchup_str = format!(
+            "{} {}",
+            &self.context,
+            desc
+        );
+        f.write_str(matchup_str.trim())
+    }
+}
+
 /// # `LeagueSeasonMatchups` struct
 ///
 /// Represents a list of matchups for a given team during a given season

--- a/src/league/season/playoffs.rs
+++ b/src/league/season/playoffs.rs
@@ -5,22 +5,531 @@ use rocket_okapi::okapi::schemars;
 #[cfg(feature = "rocket_okapi")]
 use rocket_okapi::okapi::schemars::JsonSchema;
 use rand::Rng;
-use serde::{Serialize, Deserialize};
-use std::collections::BTreeMap;
+use serde::{Serialize, Deserialize, Deserializer};
+use std::collections::{BTreeMap, HashSet};
 
 use crate::game::matchup::FootballMatchupResult;
 use crate::league::matchup::LeagueTeamRecord;
 use crate::league::season::week::LeagueSeasonWeek;
 use crate::league::season::matchup::LeagueSeasonMatchup;
 
+/// Maximum allowed length for a playoff team short name
+const MAX_PLAYOFF_TEAM_SHORT_NAME_LEN: usize = 4;
+
+/// # `PlayoffTeamRaw` struct
+///
+/// A freshly deserialized `PlayoffTeam` prior to validation.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Default, Debug, Serialize, Deserialize)]
+pub struct PlayoffTeamRaw {
+    pub seed: usize,
+    pub short_name: String,
+}
+
+impl PlayoffTeamRaw {
+    /// Validate the raw playoff team
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::PlayoffTeamRaw;
+    ///
+    /// let raw = PlayoffTeamRaw { seed: 1, short_name: "TM".to_string() };
+    /// assert!(raw.validate().is_ok());
+    /// ```
+    pub fn validate(&self) -> Result<(), String> {
+        if self.short_name.len() > MAX_PLAYOFF_TEAM_SHORT_NAME_LEN {
+            return Err(format!(
+                "Playoff team short name '{}' exceeds maximum length of {} characters",
+                self.short_name, MAX_PLAYOFF_TEAM_SHORT_NAME_LEN
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl TryFrom<PlayoffTeamRaw> for PlayoffTeam {
+    type Error = String;
+
+    fn try_from(raw: PlayoffTeamRaw) -> Result<Self, Self::Error> {
+        raw.validate()?;
+        Ok(PlayoffTeam {
+            seed: raw.seed,
+            short_name: raw.short_name,
+        })
+    }
+}
+
+/// # `PlayoffTeamsRaw` struct
+///
+/// A freshly deserialized `PlayoffTeams` prior to validation.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Default, Debug, Serialize, Deserialize)]
+pub struct PlayoffTeamsRaw {
+    pub teams: BTreeMap<usize, BTreeMap<usize, PlayoffTeam>>,
+}
+
+impl PlayoffTeamsRaw {
+    /// Validate the raw playoff teams
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::PlayoffTeamsRaw;
+    /// use std::collections::BTreeMap;
+    ///
+    /// let raw = PlayoffTeamsRaw { teams: BTreeMap::new() };
+    /// assert!(raw.validate().is_ok());
+    /// ```
+    pub fn validate(&self) -> Result<(), String> {
+        // Check for duplicate team IDs across conferences
+        let mut seen = HashSet::new();
+        for (conf_id, conference_teams) in &self.teams {
+            for &team_id in conference_teams.keys() {
+                if !seen.insert(team_id) {
+                    return Err(format!(
+                        "Duplicate team ID {} found across conferences in playoffs (detected in conference {})",
+                        team_id, conf_id
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl TryFrom<PlayoffTeamsRaw> for PlayoffTeams {
+    type Error = String;
+
+    fn try_from(raw: PlayoffTeamsRaw) -> Result<Self, Self::Error> {
+        raw.validate()?;
+        Ok(PlayoffTeams {
+            teams: raw.teams,
+        })
+    }
+}
+
+/// # `LeagueSeasonPlayoffsRaw` struct
+///
+/// A freshly deserialized `LeagueSeasonPlayoffs` prior to validation.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Default, Debug, Serialize, Deserialize)]
+pub struct LeagueSeasonPlayoffsRaw {
+    pub teams: PlayoffTeams,
+    pub conference_brackets: BTreeMap<usize, Vec<LeagueSeasonWeek>>,
+    #[serde(default)]
+    pub winners_bracket: Vec<LeagueSeasonWeek>,
+}
+
+impl LeagueSeasonPlayoffsRaw {
+    /// Validate the raw playoffs
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffsRaw;
+    /// use fbsim_core::league::season::playoffs::PlayoffTeams;
+    /// use std::collections::BTreeMap;
+    ///
+    /// let raw = LeagueSeasonPlayoffsRaw {
+    ///     teams: PlayoffTeams::new(),
+    ///     conference_brackets: BTreeMap::new(),
+    ///     winners_bracket: Vec::new(),
+    /// };
+    /// assert!(raw.validate().is_ok());
+    /// ```
+    pub fn validate(&self) -> Result<(), String> {
+        // Collect all valid team IDs from the playoff teams
+        let valid_team_ids: HashSet<usize> = self.teams.iter().collect();
+
+        // Validate all matchups in conference brackets reference valid team IDs
+        for (conf_id, rounds) in &self.conference_brackets {
+            for (round_index, round) in rounds.iter().enumerate() {
+                for (matchup_index, matchup) in round.matchups().iter().enumerate() {
+                    let home_id = *matchup.home_team();
+                    let away_id = *matchup.away_team();
+                    if !valid_team_ids.contains(&home_id) {
+                        return Err(format!(
+                            "Conference {} bracket round {} matchup {} references nonexistent home team ID: {}",
+                            conf_id, round_index, matchup_index, home_id
+                        ));
+                    }
+                    if !valid_team_ids.contains(&away_id) {
+                        return Err(format!(
+                            "Conference {} bracket round {} matchup {} references nonexistent away team ID: {}",
+                            conf_id, round_index, matchup_index, away_id
+                        ));
+                    }
+                }
+            }
+        }
+
+        // Validate all matchups in the winners bracket reference valid team IDs
+        for (round_index, round) in self.winners_bracket.iter().enumerate() {
+            for (matchup_index, matchup) in round.matchups().iter().enumerate() {
+                let home_id = *matchup.home_team();
+                let away_id = *matchup.away_team();
+                if !valid_team_ids.contains(&home_id) {
+                    return Err(format!(
+                        "Winners bracket round {} matchup {} references nonexistent home team ID: {}",
+                        round_index, matchup_index, home_id
+                    ));
+                }
+                if !valid_team_ids.contains(&away_id) {
+                    return Err(format!(
+                        "Winners bracket round {} matchup {} references nonexistent away team ID: {}",
+                        round_index, matchup_index, away_id
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl TryFrom<LeagueSeasonPlayoffsRaw> for LeagueSeasonPlayoffs {
+    type Error = String;
+
+    fn try_from(raw: LeagueSeasonPlayoffsRaw) -> Result<Self, Self::Error> {
+        raw.validate()?;
+        Ok(LeagueSeasonPlayoffs {
+            teams: raw.teams,
+            conference_brackets: raw.conference_brackets,
+            winners_bracket: raw.winners_bracket,
+        })
+    }
+}
+
+/// # `PlayoffTeam` struct
+///
+/// Represents a single team's playoff entry with its seed and short name.
+#[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Default, Debug, Serialize)]
+pub struct PlayoffTeam {
+    seed: usize,
+    short_name: String,
+}
+
+impl<'de> Deserialize<'de> for PlayoffTeam {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = PlayoffTeamRaw::deserialize(deserializer)?;
+        PlayoffTeam::try_from(raw).map_err(serde::de::Error::custom)
+    }
+}
+
+impl PlayoffTeam {
+    /// Get the team's playoff seed
+    pub fn seed(&self) -> usize {
+        self.seed
+    }
+
+    /// Get the team's short name
+    pub fn short_name(&self) -> &str {
+        &self.short_name
+    }
+}
+
+/// # `PlayoffTeams` struct
+///
+/// A collection of teams participating in the playoffs, organized by conference.
+/// Conference ID 0 is used for non-conference playoffs.
+#[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Default, Debug, Serialize)]
+pub struct PlayoffTeams {
+    /// conference_id -> team_id -> PlayoffTeam
+    teams: BTreeMap<usize, BTreeMap<usize, PlayoffTeam>>,
+}
+
+impl PlayoffTeams {
+    /// Create a new empty PlayoffTeams collection
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::PlayoffTeams;
+    ///
+    /// let my_teams = PlayoffTeams::new();
+    /// ```
+    pub fn new() -> PlayoffTeams {
+        PlayoffTeams::default()
+    }
+
+    /// Add a team to the playoffs
+    ///
+    /// Teams are expected to be added in seed order within each conference.
+    /// Seed is calculated based on number of teams already in the conference bracket.
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::PlayoffTeams;
+    ///
+    /// let mut my_teams = PlayoffTeams::new();
+    /// let res = my_teams.add(
+    ///     0,          // Team ID
+    ///     "TM",       // Short name
+    ///     0           // Conference ID
+    /// );
+    /// assert!(res.is_ok());
+    /// ```
+    pub fn add(&mut self, team_id: usize, short_name: &str, conference: usize) -> Result<(), String> {
+        let conference_teams = self.teams.entry(conference).or_default();
+        if conference_teams.contains_key(&team_id) {
+            return Err(format!("Team {} is already in conference {}", team_id, conference));
+        }
+
+        let seed = conference_teams.len() + 1;
+        conference_teams.insert(team_id, PlayoffTeam {
+            seed,
+            short_name: short_name.to_string(),
+        });
+        Ok(())
+    }
+
+    /// Get a team by ID (searches all conferences)
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::PlayoffTeams;
+    ///
+    /// let mut my_teams = PlayoffTeams::new();
+    /// let _ = my_teams.add(0, "TM", 0);
+    ///
+    /// let existing_team = my_teams.get(0);
+    /// assert!(existing_team.is_some());
+    /// assert!(existing_team.unwrap().seed() == 1);
+    ///
+    /// let nonexistent_team = my_teams.get(1);
+    /// assert!(nonexistent_team.is_none());
+    /// ```
+    pub fn get(&self, team_id: usize) -> Option<&PlayoffTeam> {
+        for conference_teams in self.teams.values() {
+            if let Some(team) = conference_teams.get(&team_id) {
+                return Some(team);
+            }
+        }
+        None
+    }
+
+    /// Get all teams in a specific conference
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::PlayoffTeams;
+    ///
+    /// let mut my_teams = PlayoffTeams::new();
+    /// let _ = my_teams.add(0, "A", 0);
+    /// let _ = my_teams.add(1, "B", 0);
+    /// let _ = my_teams.add(2, "C", 1);
+    /// let _ = my_teams.add(3, "D", 1);
+    ///
+    /// let existing_conference = my_teams.get_conference(1);
+    /// assert!(existing_conference.is_some());
+    /// assert_eq!(existing_conference.unwrap().len(), 2);
+    ///
+    /// let nonexistent_conference = my_teams.get_conference(2);
+    /// assert!(nonexistent_conference.is_none());
+    /// ```
+    pub fn get_conference(&self, conference: usize) -> Option<&BTreeMap<usize, PlayoffTeam>> {
+        self.teams.get(&conference)
+    }
+
+    /// Check if a team is in the playoffs
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::PlayoffTeams;
+    ///
+    /// let mut my_teams = PlayoffTeams::new();
+    /// let _ = my_teams.add(0, "A", 0);
+    /// assert!(my_teams.contains(0));  // Existing team
+    /// assert!(!my_teams.contains(1)); // Nonexistent team
+    /// ```
+    pub fn contains(&self, team_id: usize) -> bool {
+        self.get(team_id).is_some()
+    }
+
+    /// Get the total number of teams across all conferences
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::PlayoffTeams;
+    ///
+    /// let mut my_teams = PlayoffTeams::new();
+    /// let _ = my_teams.add(0, "A", 0);
+    /// assert!(my_teams.len() == 1);
+    /// ```
+    pub fn len(&self) -> usize {
+        self.teams.values().map(|c| c.len()).sum()
+    }
+
+    /// Check if there are no teams
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::PlayoffTeams;
+    ///
+    /// let mut my_teams = PlayoffTeams::new();
+    /// assert!(my_teams.is_empty());
+    ///
+    /// // Add a team which should cause the playoffs to become nonempty
+    /// let _ = my_teams.add(0, "A", 0);
+    /// assert!(!my_teams.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.teams.is_empty() || self.teams.values().all(|c| c.is_empty())
+    }
+
+    /// Get the number of conferences
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::PlayoffTeams;
+    ///
+    /// let mut my_teams = PlayoffTeams::new();
+    /// let _ = my_teams.add(0, "A", 0);
+    /// let _ = my_teams.add(1, "B", 0);
+    /// let _ = my_teams.add(2, "C", 1);
+    /// let _ = my_teams.add(3, "D", 1);
+    /// assert!(my_teams.num_conferences() == 2);
+    /// ```
+    pub fn num_conferences(&self) -> usize {
+        self.teams.len()
+    }
+
+    /// Iterate over conference IDs
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::PlayoffTeams;
+    ///
+    /// let mut my_teams = PlayoffTeams::new();
+    /// let _ = my_teams.add(0, "A", 0);
+    /// let _ = my_teams.add(1, "B", 0);
+    /// let _ = my_teams.add(2, "C", 1);
+    /// let _ = my_teams.add(3, "D", 1);
+    /// for (i, conference) in my_teams.conferences().enumerate() {
+    ///     assert!(i == *conference); // Note conference IDs are borrowed
+    /// }
+    /// ```
+    pub fn conferences(&self) -> impl Iterator<Item = &usize> {
+        self.teams.keys()
+    }
+
+    /// Iterate over all teams across all conferences
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::PlayoffTeams;
+    ///
+    /// let mut my_teams = PlayoffTeams::new();
+    /// let _ = my_teams.add(0, "A", 0);
+    /// let _ = my_teams.add(1, "B", 0);
+    /// let _ = my_teams.add(2, "C", 1);
+    /// let _ = my_teams.add(3, "D", 1);
+    /// let team_ids: Vec<usize> = my_teams.iter().collect();
+    /// assert_eq!(team_ids, vec![0, 1, 2, 3]);
+    /// ```
+    pub fn iter(&self) -> impl Iterator<Item = usize> + '_ {
+        self.teams.values().flat_map(|c| c.keys().copied())
+    }
+
+    /// Get teams in a conference sorted by seed
+    ///
+    /// Returns a vector of `(team_id, &PlayoffTeam)` pairs sorted by seed.
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::PlayoffTeams;
+    ///
+    /// let mut my_teams = PlayoffTeams::new();
+    /// let _ = my_teams.add(3, "A", 0);
+    /// let _ = my_teams.add(1, "B", 0);
+    /// let by_seed = my_teams.conference_teams_by_seed(0);
+    /// assert_eq!(by_seed.len(), 2);
+    /// assert_eq!(by_seed[0].0, 3); // team_id 3 is seed 1
+    /// assert_eq!(by_seed[1].0, 1); // team_id 1 is seed 2
+    /// ```
+    pub fn conference_teams_by_seed(&self, conference: usize) -> Vec<(usize, &PlayoffTeam)> {
+        if let Some(conference_teams) = self.teams.get(&conference) {
+            let mut teams: Vec<(usize, &PlayoffTeam)> = conference_teams
+                .iter()
+                .map(|(&team_id, team)| (team_id, team))
+                .collect();
+            teams.sort_by_key(|(_, team)| team.seed);
+            teams
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Get a team by seed within a specific conference
+    ///
+    /// Returns a `(team_id, &PlayoffTeam)` pair if found.
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::PlayoffTeams;
+    ///
+    /// let mut my_teams = PlayoffTeams::new();
+    /// let _ = my_teams.add(0, "A", 0);
+    ///
+    /// let existing_team = my_teams.get_by_seed(
+    ///     0,  // Conference ID
+    ///     1   // Team seed
+    /// );
+    /// assert!(existing_team.is_some());
+    /// let (team_id, team) = existing_team.unwrap();
+    /// assert!(team_id == 0);
+    /// assert!(team.seed() == 1);
+    ///
+    /// let nonexistent_team = my_teams.get_by_seed(0, 2);
+    /// assert!(nonexistent_team.is_none());
+    /// ```
+    pub fn get_by_seed(&self, conference: usize, seed: usize) -> Option<(usize, &PlayoffTeam)> {
+        self.teams
+            .get(&conference)?
+            .iter()
+            .find(|(_, team)| team.seed == seed)
+            .map(|(&team_id, team)| (team_id, team))
+    }
+}
+
+impl<'de> Deserialize<'de> for PlayoffTeams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = PlayoffTeamsRaw::deserialize(deserializer)?;
+        PlayoffTeams::try_from(raw).map_err(serde::de::Error::custom)
+    }
+}
+
 /// # `LeagueSeasonPlayoffs` struct
 ///
-/// A `LeagueSeasonPlayoffs` represents football season playoffs
+/// A `LeagueSeasonPlayoffs` represents football season playoffs.
+///
+/// Rounds are organized by conference bracket ID. Single-conference (non-conference)
+/// playoffs use bracket ID 0. Multi-conference playoffs have one bracket per
+/// conference, plus a `winners_bracket` for the championship between conference winners.
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Default, Debug, Serialize, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Default, Debug, Serialize)]
 pub struct LeagueSeasonPlayoffs {
-    teams: BTreeMap<usize, (usize, String)>,
-    rounds: Vec<LeagueSeasonWeek>
+    /// Teams participating in the playoffs
+    teams: PlayoffTeams,
+    /// Conference bracket ID -> rounds for that bracket.
+    /// Single-conference playoffs use bracket ID 0.
+    conference_brackets: BTreeMap<usize, Vec<LeagueSeasonWeek>>,
+    /// Winners bracket for championship game(s) between conference champions.
+    /// Only used in multi-conference playoffs.
+    #[serde(default)]
+    winners_bracket: Vec<LeagueSeasonWeek>,
+}
+
+impl<'de> Deserialize<'de> for LeagueSeasonPlayoffs {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = LeagueSeasonPlayoffsRaw::deserialize(deserializer)?;
+        LeagueSeasonPlayoffs::try_from(raw).map_err(serde::de::Error::custom)
+    }
 }
 
 impl LeagueSeasonPlayoffs {
@@ -36,56 +545,84 @@ impl LeagueSeasonPlayoffs {
         LeagueSeasonPlayoffs::default()
     }
 
-    /// Determine whether the playoffs have started
+    /// Borrow the winners bracket
     ///
     /// ### Example
     /// ```
     /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffs;
     ///
     /// let my_playoffs = LeagueSeasonPlayoffs::new();
-    /// assert!(!my_playoffs.started());
+    /// let winners_bracket = my_playoffs.winners_bracket();
     /// ```
-    pub fn started(&self) -> bool {
-        // If no rounds generated yet, they haven't started
-        if self.rounds.is_empty() {
-            return false;
-        }
-
-        // If any rounds have started, the playoffs have started
-        for round in self.rounds.iter() {
-            if round.started() {
-                return true;
-            }
-        }
-
-        // If no rounds have started, the playoffs have not started
-        false
+    pub fn winners_bracket(&self) -> &Vec<LeagueSeasonWeek> {
+        &self.winners_bracket
     }
 
-    /// Borrow the playoff rounds
-    ///
-    /// ### Example
-    /// ```
-    /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffs;
-    ///
-    /// let my_playoffs = LeagueSeasonPlayoffs::new();
-    /// let rounds = my_playoffs.rounds();
-    /// ```
-    pub fn rounds(&self) -> &Vec<LeagueSeasonWeek> {
-        &self.rounds
-    }
-
-    /// Mutably borrow the playoff rounds
+    /// Mutably borrow the winners bracket
     ///
     /// ### Example
     /// ```
     /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffs;
     ///
     /// let mut my_playoffs = LeagueSeasonPlayoffs::new();
-    /// let rounds = my_playoffs.rounds_mut();
+    /// let winners_bracket = my_playoffs.winners_bracket_mut();
     /// ```
-    pub fn rounds_mut(&mut self) -> &mut Vec<LeagueSeasonWeek> {
-        &mut self.rounds
+    pub fn winners_bracket_mut(&mut self) -> &mut Vec<LeagueSeasonWeek> {
+        &mut self.winners_bracket
+    }
+
+    /// Borrow the playoffs' conference brackets
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffs;
+    ///
+    /// let my_playoffs = LeagueSeasonPlayoffs::new();
+    /// let conference_brackets = my_playoffs.conference_brackets();
+    /// ```
+    pub fn conference_brackets(&self) -> &BTreeMap<usize, Vec<LeagueSeasonWeek>> {
+        &self.conference_brackets
+    }
+
+    /// Mutably borrow the playoffs' conference brackets
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffs;
+    ///
+    /// let mut my_playoffs = LeagueSeasonPlayoffs::new();
+    /// let conference_brackets = my_playoffs.conference_brackets_mut();
+    /// ```
+    pub fn conference_brackets_mut(&mut self) -> &mut BTreeMap<usize, Vec<LeagueSeasonWeek>> {
+        &mut self.conference_brackets
+    }
+
+    /// Get the rounds for a specific conference
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffs;
+    ///
+    /// let my_playoffs = LeagueSeasonPlayoffs::new();
+    /// let conference_bracket = my_playoffs.conference_bracket(0);
+    /// assert!(conference_bracket.is_none());
+    /// ```
+    pub fn conference_bracket(&self, conference: usize) -> Option<&Vec<LeagueSeasonWeek>> {
+        self.conference_brackets.get(&conference)
+    }
+
+    /// Mutably get the rounds for a specific conference
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffs;
+    ///
+    /// let mut my_playoffs = LeagueSeasonPlayoffs::new();
+    /// let conference_bracket = my_playoffs.conference_bracket_mut(0);
+    /// assert!(conference_bracket.is_none());
+    /// ```
+    pub fn conference_bracket_mut(&mut self, conference: usize) -> Option<&mut Vec<LeagueSeasonWeek>> {
+        self.conference_brackets.get_mut(&conference)
     }
 
     /// Get the number of teams in the playoffs
@@ -111,12 +648,7 @@ impl LeagueSeasonPlayoffs {
     /// assert!(!my_playoffs.team_in_playoffs(0));
     /// ```
     pub fn team_in_playoffs(&self, team_id: usize) -> bool {
-        for (id, _) in self.teams.values() {
-            if *id == team_id {
-                return true;
-            }
-        }
-        false
+        self.teams.contains(team_id)
     }
 
     /// Find the seed for a given team ID
@@ -127,7 +659,7 @@ impl LeagueSeasonPlayoffs {
     ///
     /// // Create playoffs and add a team
     /// let mut my_playoffs = LeagueSeasonPlayoffs::new();
-    /// let _ = my_playoffs.add_team(0, "ME");
+    /// let _ = my_playoffs.add_team(0, "ME", None);
     ///
     /// // Get that team's seed
     /// let seed = my_playoffs.team_seed(0);
@@ -135,12 +667,313 @@ impl LeagueSeasonPlayoffs {
     /// assert!(seed.unwrap() == 1);
     /// ```
     pub fn team_seed(&self, team_id: usize) -> Result<usize, String> {
-        for (seed, (id, _)) in &self.teams {
-            if *id == team_id {
-                return Ok(*seed);
+        self.teams
+            .get(team_id)
+            .map(|team| team.seed())
+            .ok_or_else(|| format!("Team {} not in playoffs", team_id))
+    }
+
+    /// Find the conference for a given team ID
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffs;
+    ///
+    /// // Create playoffs and add a team
+    /// let mut my_playoffs = LeagueSeasonPlayoffs::new();
+    /// let _ = my_playoffs.add_team(0, "ME", Some(0));
+    ///
+    /// // Get that team's conference
+    /// let seed = my_playoffs.team_conference(0);
+    /// assert!(seed.is_ok());
+    /// assert!(seed.unwrap() == 0);
+    /// ```
+    pub fn team_conference(&self, team_id: usize) -> Result<usize, String> {
+        if !self.teams.contains(team_id) {
+            return Err(
+                format!(
+                    "Team {} does not exist in playoffs",
+                    team_id
+                )
+            )
+        }
+        for conference in self.teams.conferences() {
+            if let Some(c) = self.teams.get_conference(*conference) {
+                for id in c.keys() {
+                    if *id == team_id {
+                        return Ok(*conference);
+                    }
+                }
             }
         }
-        Err(format!("Team {} not in playoffs", team_id))
+        Err(
+            format!(
+                "Team {} exists but was not found in any conference",
+                team_id
+            )
+        )
+    }
+
+    /// Check if this is a conference-based playoff
+    ///
+    /// Returns true if teams are spread across multiple conferences.
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffs;
+    ///
+    /// let my_playoffs = LeagueSeasonPlayoffs::new();
+    /// assert!(!my_playoffs.is_conference_playoff());
+    /// ```
+    pub fn is_conference_playoff(&self) -> bool {
+        self.teams.num_conferences() > 1
+    }
+
+    /// Get the number of conferences in the playoffs
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffs;
+    ///
+    /// let my_playoffs = LeagueSeasonPlayoffs::new();
+    /// assert_eq!(my_playoffs.num_conferences(), 0);
+    /// ```
+    pub fn num_conferences(&self) -> usize {
+        self.teams.num_conferences()
+    }
+
+    /// Get the team IDs for a specific conference bracket sorted by seed
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffs;
+    ///
+    /// let mut my_playoffs = LeagueSeasonPlayoffs::new();
+    /// let _ = my_playoffs.add_team(1, "ME", Some(0));
+    /// let teams = my_playoffs.conference_teams(0);
+    /// assert_eq!(teams.len(), 1);
+    /// ```
+    pub fn conference_teams(&self, conf_index: usize) -> Vec<(usize, &PlayoffTeam)> {
+        self.teams.conference_teams_by_seed(conf_index)
+    }
+
+    /// Determine whether a given conference bracket has started
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffs;
+    ///
+    /// let my_playoffs = LeagueSeasonPlayoffs::new();
+    /// assert!(!my_playoffs.conference_bracket_started(0));
+    /// ```
+    pub fn conference_bracket_started(&self, conference: usize) -> bool {
+        if let Some(bracket) = self.conference_brackets.get(&conference) {
+            // If any round has started, the playoffs have started
+            for round in bracket {
+                if round.started() {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Determine whether the conference brackets have sterted
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffs;
+    ///
+    /// let my_playoffs = LeagueSeasonPlayoffs::new();
+    /// assert!(!my_playoffs.conference_brackets_started());
+    /// ```
+    pub fn conference_brackets_started(&self) -> bool {
+        for (_, bracket) in self.conference_brackets.iter() {
+            // If any round has started, the playoffs have started
+            for round in bracket {
+                if round.started() {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Determine whether a given conference bracket is complete
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffs;
+    ///
+    /// let my_playoffs = LeagueSeasonPlayoffs::new();
+    /// assert!(!my_playoffs.conference_bracket_complete(0));
+    /// ```
+    pub fn conference_bracket_complete(&self, conference: usize) -> bool {
+        if let Some(bracket) = self.conference_brackets.get(&conference) {
+            // If no rounds generated yet, it hasn't completed
+            if bracket.is_empty() {
+                return false;
+            }
+            for round in bracket {
+                // If any round hasn't started or hasn't finished yet, it hasn't completed
+                if !(round.started() && round.complete()) {
+                    return false;
+                }
+
+                // This conference playoff bracket is complete when only 1 team remains
+                let conference = match self.teams.get_conference(conference) {
+                    Some(c) => c,
+                    None => return false,
+                };
+                let mut eliminated = 0;
+                for round in bracket {
+                    eliminated += round.matchups().len();
+                }
+                if conference.len() != eliminated + 1 {
+                    return false;
+                }
+            }
+            return true;
+        }
+        
+        // If no round was found, it hasn't completed
+        false
+    }
+
+    /// Determine whether the conference brackets are all complete
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffs;
+    ///
+    /// let my_playoffs = LeagueSeasonPlayoffs::new();
+    /// assert!(!my_playoffs.conference_brackets_complete());
+    /// ```
+    pub fn conference_brackets_complete(&self) -> bool {
+        // If conference brackets have not started yet, they haven't completed
+        if !self.conference_brackets_started() {
+            return false;
+        }
+
+        // Check if each conference bracket is complete, count eliminated teams
+        for (i, bracket) in self.conference_brackets.iter() {
+            // If any round is not yet complete, the playoffs are not complete
+            for round in bracket {
+                if !round.complete() {
+                    return false;
+                }
+            }
+
+            // This conference playoff bracket is complete when only 1 team remains
+            let conference = match self.teams.get_conference(*i) {
+                Some(c) => c,
+                None => return false
+            };
+            let mut eliminated = 0;
+            for round in bracket {
+                eliminated += round.matchups().len();
+            }
+            if conference.len() != eliminated + 1 {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Get the team ID of the conference champion for a specific conference
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffs;
+    ///
+    /// let my_playoffs = LeagueSeasonPlayoffs::new();
+    /// assert!(my_playoffs.conference_champion(0).is_none());
+    /// ```
+    pub fn conference_champion(&self, conference: usize) -> Option<usize> {
+        // Check if the conference bracket is complete
+        if !self.conference_bracket_complete(conference) {
+            return None;
+        }
+
+        // Get the conference champion
+        if let Some(bracket) = self.conference_brackets.get(&conference) {
+            if let Some(round) = bracket.last() {
+                if let Some(matchup) = round.matchups().first() {
+                    return matchup.winner();
+                }
+            }
+        }
+        None
+    }
+
+    /// Determine whether the winners bracket has started
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffs;
+    ///
+    /// let my_playoffs = LeagueSeasonPlayoffs::new();
+    /// assert!(!my_playoffs.winners_bracket_started());
+    /// ```
+    pub fn winners_bracket_started(&self) -> bool {
+        if !self.winners_bracket.is_empty() {
+            for round in self.winners_bracket.iter() {
+                if round.started() {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Determine whether the winners bracket is complete
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffs;
+    ///
+    /// let my_playoffs = LeagueSeasonPlayoffs::new();
+    /// assert!(!my_playoffs.winners_bracket_complete());
+    /// ```
+    pub fn winners_bracket_complete(&self) -> bool {
+        // If no winners bracket hasn't started yet, it hasn't completed
+        if !self.winners_bracket_started() {
+            return false;
+        }
+
+        // Get the final round of the winners bracket
+        if let Some(final_round) = self.winners_bracket.last() {
+            // If more than one matchup, it hasn't completed
+            let matchups = final_round.matchups().len();
+            if matchups > 1 {
+                return false;
+            }
+
+            // If one matchup and round, but more than 2 conferences, it hasn't completed
+            let conferences = self.num_conferences();
+            if self.winners_bracket.len() == 1 && matchups == 1 && conferences > 2 {
+                return false;
+            }
+
+            // If we reach this point, the one matchup left is the championship
+            if let Some(final_matchup) = final_round.matchups().first() {
+                return final_matchup.context().game_over();
+            }
+        }
+        false
+    }
+
+    /// Determine whether the playoffs have started
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffs;
+    ///
+    /// let my_playoffs = LeagueSeasonPlayoffs::new();
+    /// assert!(!my_playoffs.started());
+    /// ```
+    pub fn started(&self) -> bool {
+        self.conference_brackets_started()
     }
 
     /// Determine whether the playoffs are complete
@@ -153,88 +986,74 @@ impl LeagueSeasonPlayoffs {
     /// assert!(!my_playoffs.complete());
     /// ```
     pub fn complete(&self) -> bool {
-        // If no rounds generated yet, they haven't started
-        if self.rounds.is_empty() {
+        // If no conference brackets generated yet, they haven't started
+        // If conference brackets are not complete yet, they haven't completed
+        if self.conference_brackets.is_empty() || !self.conference_brackets_complete() {
             return false;
         }
 
-        // If any round is not yet complete, the playoffs are not complete
-        for round in self.rounds.iter() {
-            if !round.complete() {
-                return false;
-            }
+        // If conference playoff, check if winners bracket is complete
+        // Non-conference playoff, if this point is reached they are complete
+        if self.is_conference_playoff() {
+            self.winners_bracket_complete()
+        } else {
+            true
         }
-
-        // Count how many teams have been eliminated
-        let mut eliminated = 0;
-        for round in self.rounds.iter() {
-            eliminated += round.matchups().len();
-        }
-
-        // Playoffs are complete when only 1 team remains
-        self.teams.len() == eliminated + 1
     }
 
     /// Add a team to the playoffs
+    ///
+    /// If `conference` is `None`, the team is added to the default conference (0).
+    /// Teams should be added in seed order within each conference.
     ///
     /// ### Example
     /// ```
     /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffs;
     ///
     /// let mut my_playoffs = LeagueSeasonPlayoffs::new();
-    /// let res = my_playoffs.add_team(0, "ME");
+    /// // Non-conference playoff
+    /// let res = my_playoffs.add_team(0, "ME", None);
     /// assert!(res.is_ok());
+    ///
+    /// // Conference playoff
+    /// let mut conf_playoffs = LeagueSeasonPlayoffs::new();
+    /// let _ = conf_playoffs.add_team(0, "YOU", Some(0));
+    /// let _ = conf_playoffs.add_team(1, "THEM", Some(1));
     /// ```
-    pub fn add_team(&mut self, team: usize, name: &str) -> Result<(), String> {
+    pub fn add_team(&mut self, team_id: usize, name: &str, conference: Option<usize>) -> Result<(), String> {
         // Ensure the playoffs have not already started
         if self.started() {
             return Err(String::from("Playoffs have already started, cannot add new team"));
         }
 
-        // Calculate the next seed and add the team
-        let seed = self.teams.len() + 1;
-        self.teams.insert(seed, (team, String::from(name)));
-        Ok(())
+        let conf = conference.unwrap_or(0);
+        self.teams.add(team_id, name, conf)
     }
 
-    /// Get the number of teams that will appear in the first round
-    ///
-    /// ### Example
-    /// ```
-    /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffs;
-    ///
-    /// // Instantiate playoffs and add teams
-    /// let mut my_playoffs = LeagueSeasonPlayoffs::new();
-    /// let _ = my_playoffs.add_team(0, "ME");
-    /// let _ = my_playoffs.add_team(1, "YOU");
-    /// let _ = my_playoffs.add_team(2, "THEM");
-    ///
-    /// // Get the number of first round teams
-    /// let first_round_teams = my_playoffs.first_round_teams();
-    /// assert!(first_round_teams.is_ok());
-    /// assert!(first_round_teams.unwrap() == 2);
-    /// ```
-    pub fn first_round_teams(&self) -> Result<usize, String> {
-        // Ensure there are enough teams (at least 2)
-        let num_teams = self.teams.len();
+    /// Helper method to calculate the number of first round teams
+    fn num_first_round_teams(&self, num_teams: usize) -> Result<usize, String> {
         if num_teams < 2 {
-            return Err(format!("Playoffs must contain at least 2 teams, got {}", num_teams))
+            return Err(
+                format!(
+                    "Playoffs must contain at least 2 teams per conference, got {}",
+                    num_teams
+                )
+            )
         }
-
-        // Calculate the number of first round matchups
         let next_power = num_teams.checked_next_power_of_two().ok_or(
-            String::from("Failed to calculate first round matchups")
+            String::from("Failed to calculate first round conference matchups")
         )?;
         if next_power == num_teams {
             Ok(next_power)
         } else {
             next_power.checked_div(2).ok_or(
-                String::from("Failed to calculate first round matchups")
+                String::from("Failed to calculate first round conference matchups")
             )
         }
     }
 
-    /// Get the number of teams that will appear in the wild card round
+    /// Get the number of teams that will appear in the first round of a given
+    /// conference bracket
     ///
     /// ### Example
     /// ```
@@ -242,25 +1061,64 @@ impl LeagueSeasonPlayoffs {
     ///
     /// // Instantiate playoffs and add teams
     /// let mut my_playoffs = LeagueSeasonPlayoffs::new();
-    /// let _ = my_playoffs.add_team(0, "ME");
-    /// let _ = my_playoffs.add_team(1, "YOU");
-    /// let _ = my_playoffs.add_team(2, "THEM");
+    /// let _ = my_playoffs.add_team(0, "ME", None);
+    /// let _ = my_playoffs.add_team(1, "YOU", None);
+    /// let _ = my_playoffs.add_team(2, "THEM", None);
     ///
-    /// // Get the number of wild card teams
-    /// let wild_cards = my_playoffs.wild_cards();
-    /// assert!(wild_cards.is_ok());
-    /// assert!(wild_cards.unwrap() == 2);
+    /// // Get the number of first round teams
+    /// let first_round_teams = my_playoffs.first_round_teams(None);
+    /// assert!(first_round_teams.is_ok());
+    /// assert!(first_round_teams.unwrap() == 2);
     /// ```
-    pub fn wild_cards(&self) -> Result<usize, String> {
-        let num_teams = self.teams.len();
-        let first_round_teams = self.first_round_teams()?;
+    pub fn first_round_teams(&self, conference: Option<usize>) -> Result<usize, String> {
+        let conf = conference.unwrap_or_default();
+        let teams_per_conference = self.conference_teams(conf).len();
+        self.num_first_round_teams(teams_per_conference)
+    }
+
+    /// Get the number of teams that will appear in the first round of the
+    /// winners bracket
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffs;
+    ///
+    /// // Instantiate playoffs and add teams
+    /// let mut my_playoffs = LeagueSeasonPlayoffs::new();
+    /// let _ = my_playoffs.add_team(0, "A", Some(0));
+    /// let _ = my_playoffs.add_team(1, "B", Some(0));
+    /// let _ = my_playoffs.add_team(2, "C", Some(1));
+    /// let _ = my_playoffs.add_team(3, "D", Some(1));
+    /// let _ = my_playoffs.add_team(4, "E", Some(2));
+    /// let _ = my_playoffs.add_team(5, "F", Some(2));
+    ///
+    /// // Get the number of first round teams
+    /// let first_round_teams = my_playoffs.first_round_winners();
+    /// assert!(first_round_teams.is_ok());
+    /// assert!(first_round_teams.unwrap() == 2);
+    /// ```
+    pub fn first_round_winners(&self) -> Result<usize, String> {
+        let conferences = self.num_conferences();
+        match conferences {
+            0 => Err(String::from("No conferences yet to determine winners bracket")),
+            1 => Ok(0),
+            _ => self.num_first_round_teams(conferences)
+        }
+    }
+
+    /// Helper method to calculate the number of wild card teams
+    fn num_wild_card_teams(&self, num_teams: usize, first_round_teams: usize) -> Result<usize, String> {
+        if num_teams == 1 && first_round_teams == 0 {
+            return Ok(0);
+        }
         let k = num_teams.checked_sub(first_round_teams).ok_or(
             String::from("Failed to calculate wild cards")
         )?;
         Ok(2 * k)
     }
 
-    /// Get the number of teams that will have a bye
+    /// Get the number of teams that will appear in the wild card round of the
+    /// conference round
     ///
     /// ### Example
     /// ```
@@ -268,18 +1126,54 @@ impl LeagueSeasonPlayoffs {
     ///
     /// // Instantiate playoffs and add teams
     /// let mut my_playoffs = LeagueSeasonPlayoffs::new();
-    /// let _ = my_playoffs.add_team(0, "ME");
-    /// let _ = my_playoffs.add_team(1, "YOU");
-    /// let _ = my_playoffs.add_team(2, "THEM");
+    /// let _ = my_playoffs.add_team(0, "ME", None);
+    /// let _ = my_playoffs.add_team(1, "YOU", None);
+    /// let _ = my_playoffs.add_team(2, "THEM", None);
     ///
-    /// // Get the number of byes
-    /// let byes = my_playoffs.byes();
-    /// assert!(byes.is_ok());
-    /// assert!(byes.unwrap() == 1);
+    /// // Get the number of wild card teams
+    /// let wild_cards = my_playoffs.wild_cards(None);
+    /// assert!(wild_cards.is_ok());
+    /// assert!(wild_cards.unwrap() == 2);
     /// ```
-    pub fn byes(&self) -> Result<usize, String> {
-        let num_teams = self.teams.len();
-        let first_round_teams = self.first_round_teams()?;
+    pub fn wild_cards(&self, conference: Option<usize>) -> Result<usize, String> {
+        let conf = conference.unwrap_or_default();
+        let num_teams = self.conference_teams(conf).len();
+        let first_round_teams = self.first_round_teams(conference)?;
+        self.num_wild_card_teams(num_teams, first_round_teams)
+    }
+
+    /// Get the number of teams that will appear in the wild card round of the
+    /// winners bracket
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffs;
+    ///
+    /// // Instantiate playoffs and add teams
+    /// let mut my_playoffs = LeagueSeasonPlayoffs::new();
+    /// let _ = my_playoffs.add_team(0, "A", Some(0));
+    /// let _ = my_playoffs.add_team(1, "B", Some(0));
+    /// let _ = my_playoffs.add_team(2, "C", Some(1));
+    /// let _ = my_playoffs.add_team(3, "D", Some(1));
+    /// let _ = my_playoffs.add_team(4, "E", Some(2));
+    /// let _ = my_playoffs.add_team(5, "F", Some(2));
+    ///
+    /// // Get the number of first round teams
+    /// let wild_card_teams = my_playoffs.wild_card_winners();
+    /// assert!(wild_card_teams.is_ok());
+    /// assert!(wild_card_teams.unwrap() == 2);
+    /// ```
+    pub fn wild_card_winners(&self) -> Result<usize, String> {
+        let num_teams = self.num_conferences();
+        let first_round_teams = self.first_round_winners()?;
+        self.num_wild_card_teams(num_teams, first_round_teams)
+    }
+
+    /// Helper method to calculate the number of teams that will have a bye
+    fn num_bye_teams(&self, num_teams: usize, first_round_teams: usize) -> Result<usize, String> {
+        if num_teams == 0 && first_round_teams == 1 {
+            return Ok(0);
+        }
         let k = num_teams.checked_sub(first_round_teams).ok_or(
             String::from("Failed to calculate byes")
         )?;
@@ -289,80 +1183,246 @@ impl LeagueSeasonPlayoffs {
         Ok(byes)
     }
 
-    // Helper function for generating the wild card matchups
-    fn gen_wild_card_round(&mut self, rng: &mut impl Rng) -> Result<(), String> {
-        // Ensure there are enough teams (at least 2)
-        let num_teams = self.teams.len();
+    /// Get the number of teams that will have a bye in a given conference
+    /// bracket
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffs;
+    ///
+    /// // Instantiate playoffs and add teams
+    /// let mut my_playoffs = LeagueSeasonPlayoffs::new();
+    /// let _ = my_playoffs.add_team(0, "ME", None);
+    /// let _ = my_playoffs.add_team(1, "YOU", None);
+    /// let _ = my_playoffs.add_team(2, "THEM", None);
+    ///
+    /// // Get the number of byes
+    /// let byes = my_playoffs.byes(None);
+    /// assert!(byes.is_ok());
+    /// assert!(byes.unwrap() == 1);
+    /// ```
+    pub fn byes(&self, conference: Option<usize>) -> Result<usize, String> {
+        let conf = conference.unwrap_or_default();
+        let num_teams = self.conference_teams(conf).len();
+        let first_round_teams = self.first_round_teams(conference)?;
+        self.num_bye_teams(num_teams, first_round_teams)
+    }
+
+    /// Get the number of teams that will have a bye in the winners bracket
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffs;
+    ///
+    /// // Instantiate playoffs and add teams
+    /// let mut my_playoffs = LeagueSeasonPlayoffs::new();
+    /// let _ = my_playoffs.add_team(0, "A", Some(0));
+    /// let _ = my_playoffs.add_team(1, "B", Some(0));
+    /// let _ = my_playoffs.add_team(2, "C", Some(1));
+    /// let _ = my_playoffs.add_team(3, "D", Some(1));
+    /// let _ = my_playoffs.add_team(4, "E", Some(2));
+    /// let _ = my_playoffs.add_team(5, "F", Some(2));
+    ///
+    /// // Get the number of winners bracket first round byes
+    /// let winners_bracket_byes = my_playoffs.winners_bracket_byes();
+    /// assert!(winners_bracket_byes.is_ok());
+    /// assert!(winners_bracket_byes.unwrap() == 1);
+    /// ```
+    pub fn winners_bracket_byes(&self) -> Result<usize, String> {
+        let num_teams = self.num_conferences();
+        let first_round_teams = self.first_round_winners()?;
+        self.num_bye_teams(num_teams, first_round_teams)
+    }
+
+    /// Helper method for generating a conference's wild card matchups
+    fn gen_conference_wild_card_round(&mut self, conference: usize, rng: &mut impl Rng) -> Result<(), String> {
+        // Ensure conditions are valid to generate conference wild card round
+        let num_teams = self.conference_teams(conference).len();
         if num_teams < 2 {
-            return Err(format!("Playoffs must contain at least 2 teams, got {}", num_teams))
+            return Err(
+                format!(
+                    "Conference {} bracket must contain at least 2 teams, got {}",
+                    conference,
+                    num_teams
+                )
+            )
         }
-
-        // Ensure the number of teams is not a power of 2
         if num_teams.is_power_of_two() {
-            return Err(format!("No wild card round for playoffs with a power of 2 teams: {}", num_teams))
+            return Err(
+                format!(
+                    "No wild card round for conference {} bracket with a power of 2 teams: {}",
+                    conference,
+                    num_teams
+                )
+            )
+        }
+        if self.conference_brackets_started() {
+            return Err(
+                String::from(
+                    "Cannot re-generate wild card rounds, conference playoffs already started"
+                )
+            )
         }
 
-        // Ensure the playoffs have not yet started
-        if self.started() {
-            return Err(String::from("Cannot re-generate wild card round, playoffs already started"))
-        }
-
-        // If rounds exist already, clear them
-        if !self.rounds.is_empty() {
-            self.rounds = Vec::new();
-        }
+        // Clear conference bracket if it already exists
+        self.conference_brackets.insert(conference, Vec::new());
 
         // Get the number of wild card teams and byes
-        let byes = self.byes()?;
-        let wild_cards = self.wild_cards()?;
+        let byes = self.byes(Some(conference))?;
+        let wild_cards = self.wild_cards(Some(conference))?;
         let wild_card_matchups = wild_cards.checked_div(2).ok_or(
             String::from("Failed to calculate wild card matchups")
+        )?;
+
+        // Match up the wild card teams against one another (using default conference 0)
+        let mut week = LeagueSeasonWeek::new();
+        for i in 0..wild_card_matchups {
+            // Get the home and away teams by seed
+            let home_seed = byes + i + 1;
+            let away_seed = num_teams - i;
+            let (home_team_id, home_team) = self.teams.get_by_seed(conference, home_seed)
+                .ok_or_else(|| format!(
+                    "No team found in conference {} with seed {}",
+                    conference,
+                    home_seed
+                ))?;
+            let (away_team_id, away_team) = self.teams.get_by_seed(conference, away_seed)
+                .ok_or_else(|| format!(
+                    "No team found in conference {} with seed {}",
+                    conference,
+                    away_seed
+                ))?;
+
+            // Create the matchup and add to the week
+            let matchup = LeagueSeasonMatchup::new(
+                home_team_id,
+                away_team_id,
+                home_team.short_name(),
+                away_team.short_name(),
+                rng
+            );
+            week.matchups_mut().push(matchup);
+        }
+
+        // Add the week to the conference bracket and return
+        self.conference_brackets.entry(conference).or_default().push(week);
+        Ok(())
+    }
+
+    /// Helper method for generating the winners bracket's wild card matchups
+    fn gen_winners_wild_card_round(&mut self, rng: &mut impl Rng) -> Result<(), String> {
+        // Ensure conditions are valid to generate conference wild card round
+        let num_teams = self.num_conferences();
+        if num_teams < 2 {
+            return Err(
+                format!(
+                    "Must contain at least 2 conferences for a winners bracket, got {}",
+                    num_teams
+                )
+            )
+        }
+        if num_teams.is_power_of_two() {
+            return Err(
+                format!(
+                    "No wild card round for winners bracket with a power of 2 teams: {}",
+                    num_teams
+                )
+            )
+        }
+        if !self.conference_brackets_complete() {
+            return Err(
+                String::from(
+                    "Cannot generate winners bracket, conference playoffs not complete"
+                )
+            )
+        }
+        if self.winners_bracket_started() {
+            return Err(
+                String::from(
+                    "Cannot re-generate winners bracket, already started"
+                )
+            )
+        }
+
+        // Clear winners bracket if it already exists
+        self.winners_bracket = Vec::new();
+
+        // Get the number of wild card teams and byes
+        let byes = self.winners_bracket_byes()?;
+        let wild_cards = self.wild_card_winners()?;
+        let wild_card_matchups = wild_cards.checked_div(2).ok_or(
+            String::from(
+                "Failed to calculate wild card matchups for winners bracket"
+            )
         )?;
 
         // Match up the wild card teams against one another
         let mut week = LeagueSeasonWeek::new();
         for i in 0..wild_card_matchups {
-            // Get the home and away IDs
-            let home_seed = byes + i + 1;
-            let away_seed = num_teams - i;
-            let (home_id, home_name) = match self.teams.get(&home_seed) {
-                Some(t) => t,
-                None => return Err(format!("No team found with seed {}", home_seed))
-            };
-            let (away_id, away_name) = match self.teams.get(&away_seed) {
-                Some(t) => t,
-                None => return Err(format!("No team found with seed {}", away_seed))
-            };
+            // TODO: Eventually we should have the winners bracket byes be
+            // determined by each conference champion's performance in the
+            // regular season and playoffs
+
+            // Get the conference champions by conference ID
+            let home_conf_id = byes + i;
+            let away_conf_id = num_teams - (i + 1);
+            let home_team_id = self.conference_champion(home_conf_id)
+                .ok_or_else(|| format!(
+                    "No conference champion found for conference {}",
+                    home_conf_id
+                ))?;
+            let home_team = self.teams.get(home_team_id).unwrap();
+            let away_team_id = self.conference_champion(away_conf_id)
+                .ok_or_else(|| format!(
+                    "No conference champion found for conference {}",
+                    away_conf_id
+                ))?;
+            let away_team = self.teams.get(away_team_id).unwrap();
 
             // Create the matchup and add to the week
-            let matchup = LeagueSeasonMatchup::new(*home_id, *away_id, home_name, away_name, rng);
+            let matchup = LeagueSeasonMatchup::new(
+                home_team_id,
+                away_team_id,
+                home_team.short_name(),
+                away_team.short_name(),
+                rng
+            );
             week.matchups_mut().push(matchup);
         }
 
-        // Add the week to the rounds and return
-        self.rounds.push(week);
+        // Add the week to the conference bracket and return
+        self.winners_bracket.push(week);
         Ok(())
     }
 
-    // Helper function for generating the first round matchups
-    fn gen_first_round(&mut self, rng: &mut impl Rng) -> Result<(), String> {
+    /// Helper method for generating a conference's first round matchups
+    fn gen_conference_first_round(&mut self, conference: usize, rng: &mut impl Rng) -> Result<(), String> {
         // Ensure there are enough teams (at least 2)
-        let num_teams = self.teams.len();
+        let num_teams = self.conference_teams(conference).len();
         if num_teams < 2 {
-            return Err(format!("Playoffs must contain at least 2 teams, got {}", num_teams))
+            return Err(
+                format!(
+                    "Conference {} bracket must contain at least 2 teams, got {}",
+                    conference,
+                    num_teams
+                )
+            )
         }
 
         if num_teams.is_power_of_two() {
             // In this case, there is no wild-card round, this is a true first round
             // Ensure the playoffs have not yet started
-            if self.started() {
-                return Err(String::from("Cannot re-generate first round, playoffs already started"))
+            if self.conference_brackets_started() {
+                return Err(
+                    format!(
+                        "Cannot re-generate first round, conference {} playoffs already started",
+                        conference
+                    )
+                )
             }
 
-            // If rounds exist already, clear them
-            if !self.rounds.is_empty() {
-                self.rounds = Vec::new();
-            }
+            // Clear conference bracket if it already exists
+            self.conference_brackets.insert(conference, Vec::new());
 
             // Match up the first round teams against one another
             let first_round_matchups = num_teams.checked_div(2).ok_or(
@@ -370,48 +1430,62 @@ impl LeagueSeasonPlayoffs {
             )?;
             let mut week = LeagueSeasonWeek::new();
             for i in 0..first_round_matchups {
-                // Get the home and away IDs
+                // Get the home and away teams by seed
                 let home_seed = i + 1;
                 let away_seed = num_teams - i;
-                let (home_id, home_name) = match self.teams.get(&home_seed) {
-                    Some(t) => t,
-                    None => return Err(format!("No team found with seed {}", home_seed))
-                };
-                let (away_id, away_name) = match self.teams.get(&away_seed) {
-                    Some(t) => t,
-                    None => return Err(format!("No team found with seed {}", away_seed))
-                };
+                let (home_team_id, home_team) = self.teams.get_by_seed(conference, home_seed)
+                    .ok_or_else(|| format!(
+                        "No team found in conference {} with seed {}",
+                        conference,
+                        home_seed
+                    ))?;
+                let (away_team_id, away_team) = self.teams.get_by_seed(conference, away_seed)
+                    .ok_or_else(|| format!(
+                        "No team found in conference {} with seed {}",
+                        conference,
+                        away_seed
+                    ))?;
 
                 // Create the matchup and add to the week
-                let matchup = LeagueSeasonMatchup::new(*home_id, *away_id, home_name, away_name, rng);
+                let matchup = LeagueSeasonMatchup::new(
+                    home_team_id,
+                    away_team_id,
+                    home_team.short_name(),
+                    away_team.short_name(),
+                    rng
+                );
                 week.matchups_mut().push(matchup);
             }
 
-            // Add the week to the rounds and return
-            self.rounds.push(week);
+            // Add the week to the conference bracket and return
+            self.conference_brackets.entry(conference).or_default().push(week);
             Ok(())
         } else {
             // In this case, we need to determine the winners of the wild card round
-            // Ensure only the wild card round exists
-            let rounds = self.rounds.len();
+            // Ensure only the wild card round exists in the conference bracket
+            let rounds = self.conference_brackets.get(&conference).map(|b| b.len()).unwrap_or(0);
             if rounds > 1 {
-                return Err(format!("Expected only 1 round, found {}", rounds));
+                return Err(
+                    format!(
+                        "Expected only 1 round for conference {}, found {}",
+                        conference,
+                        rounds
+                    )
+                );
             }
 
-            // Get the wild card round
-            let round = match self.rounds.last() {
+            // Get the seeds of the wild card winners from the conference bracket
+            let round = match self.conference_brackets.get(&conference).and_then(|b| b.last()) {
                 Some(r) => r,
                 None => return Err(String::from("Wild card round not found"))
             };
-
-            // Get the seed of each wild card matchup winner and number of byes
             let winner_seeds: Vec<usize> = round.matchups().iter().map(
                 |x| self.team_seed(x.winner().unwrap()).unwrap()
             ).collect();
             let num_winners = winner_seeds.len();
-            let byes = self.byes()?;
+            let byes = self.byes(Some(conference))?;
 
-            // Populate the week with matchups
+            // Populate the round with matchups
             let mut week = LeagueSeasonWeek::new();
             if num_winners >= byes {
                 // Match up winners of middle-ranked matchups with byes
@@ -422,17 +1496,27 @@ impl LeagueSeasonPlayoffs {
                         Some(s) => *s,
                         None => return Err(format!("No winner found at index {}", winner_index))
                     };
-                    let (home_id, home_name) = match self.teams.get(&bye_seed) {
-                        Some(t) => t,
-                        None => return Err(format!("No team found with seed {}", bye_seed))
-                    };
-                    let (away_id, away_name) = match self.teams.get(&winner_seed) {
-                        Some(t) => t,
-                        None => return Err(format!("No team found with seed {}", winner_seed))
-                    };
+                    let (home_team_id, home_team) = self.teams.get_by_seed(conference, bye_seed)
+                        .ok_or_else(|| format!(
+                            "No team found in conference {} with seed {}",
+                            conference,
+                            bye_seed
+                        ))?;
+                    let (away_team_id, away_team) = self.teams.get_by_seed(conference, winner_seed)
+                        .ok_or_else(|| format!(
+                            "No team found in conference {} with seed {}",
+                            conference,
+                            winner_seed
+                        ))?;
 
                     // Create the matchup and add to the week
-                    let matchup = LeagueSeasonMatchup::new(*home_id, *away_id, home_name, away_name, rng);
+                    let matchup = LeagueSeasonMatchup::new(
+                        home_team_id,
+                        away_team_id,
+                        home_team.short_name(),
+                        away_team.short_name(),
+                        rng
+                    );
                     week.matchups_mut().push(matchup);
                 }
 
@@ -452,31 +1536,32 @@ impl LeagueSeasonPlayoffs {
                         None => return Err(format!("No winner found at index {}", t2_index))
                     };
                     // Lower seed gets home field advantage
-                    let (home_id, home_name) = if t1_seed < t2_seed {
-                        match self.teams.get(&t1_seed) {
-                            Some(t) => t,
-                            None => return Err(format!("No team found with seed {}", t1_seed))
-                        }
+                    let (home_seed, away_seed) = if t1_seed < t2_seed {
+                        (t1_seed, t2_seed)
                     } else {
-                        match self.teams.get(&t2_seed) {
-                            Some(t) => t,
-                            None => return Err(format!("No team found with seed {}", t2_seed))
-                        }
+                        (t2_seed, t1_seed)
                     };
-                    let (away_id, away_name) = if t1_seed < t2_seed {
-                        match self.teams.get(&t2_seed) {
-                            Some(t) => t,
-                            None => return Err(format!("No team found with seed {}", t2_seed))
-                        }
-                    } else {
-                        match self.teams.get(&t1_seed) {
-                            Some(t) => t,
-                            None => return Err(format!("No team found with seed {}", t1_seed))
-                        }
-                    };
+                    let (home_team_id, home_team) = self.teams.get_by_seed(conference, home_seed)
+                        .ok_or_else(|| format!(
+                            "No team found in conference {} with seed {}",
+                            conference,
+                            home_seed
+                        ))?;
+                    let (away_team_id, away_team) = self.teams.get_by_seed(conference, away_seed)
+                        .ok_or_else(|| format!(
+                            "No team found in conference {} with seed {}",
+                            conference,
+                            away_seed
+                        ))?;
 
                     // Create the matchup and add to the week
-                    let matchup = LeagueSeasonMatchup::new(*home_id, *away_id, home_name, away_name, rng);
+                    let matchup = LeagueSeasonMatchup::new(
+                        home_team_id,
+                        away_team_id,
+                        home_team.short_name(),
+                        away_team.short_name(),
+                        rng
+                    );
                     week.matchups_mut().push(matchup);
                 }
             } else {
@@ -488,17 +1573,27 @@ impl LeagueSeasonPlayoffs {
                         Some(s) => *s,
                         None => return Err(format!("No winner found at index {}", winner_index))
                     };
-                    let (home_id, home_name) = match self.teams.get(&bye_seed) {
-                        Some(t) => t,
-                        None => return Err(format!("No team found with seed {}", bye_seed))
-                    };
-                    let (away_id, away_name) = match self.teams.get(&winner_seed) {
-                        Some(t) => t,
-                        None => return Err(format!("No team found with seed {}", winner_seed))
-                    };
+                    let (home_team_id, home_team) = self.teams.get_by_seed(conference, bye_seed)
+                        .ok_or_else(|| format!(
+                            "No team found in conference {} with seed {}",
+                            conference,
+                            bye_seed
+                        ))?;
+                    let (away_team_id, away_team) = self.teams.get_by_seed(conference, winner_seed)
+                        .ok_or_else(|| format!(
+                            "No team found in conference {} with seed {}",
+                            conference,
+                            winner_seed
+                        ))?;
 
                     // Create the matchup and add to the week
-                    let matchup = LeagueSeasonMatchup::new(*home_id, *away_id, home_name, away_name, rng);
+                    let matchup = LeagueSeasonMatchup::new(
+                        home_team_id,
+                        away_team_id,
+                        home_team.short_name(),
+                        away_team.short_name(),
+                        rng
+                    );
                     week.matchups_mut().push(matchup);
                 }
 
@@ -510,22 +1605,592 @@ impl LeagueSeasonPlayoffs {
                 for i in 0..diff_winner_matchups {
                     let t1_seed = num_winners + i + 1;
                     let t2_seed = byes - i;
-                    let (home_id, home_name) = match self.teams.get(&t1_seed) {
-                            Some(t) => t,
-                            None => return Err(format!("No team found with seed {}", t1_seed))
-                        };
-                    let (away_id, away_name) = match self.teams.get(&t2_seed) {
-                        Some(t) => t,
-                        None => return Err(format!("No team found with seed {}", t2_seed))
-                    };
+                    let (home_team_id, home_team) = self.teams.get_by_seed(conference, t1_seed)
+                        .ok_or_else(|| format!(
+                            "No team found in conference {} with seed {}",
+                            conference,
+                            t1_seed
+                        ))?;
+                    let (away_team_id, away_team) = self.teams.get_by_seed(conference, t2_seed)
+                        .ok_or_else(|| format!(
+                            "No team found in conference {} with seed {}",
+                            conference,
+                            t2_seed
+                        ))?;
 
                     // Create the matchup and add to the week
-                    let matchup = LeagueSeasonMatchup::new(*home_id, *away_id, home_name, away_name, rng);
+                    let matchup = LeagueSeasonMatchup::new(
+                        home_team_id,
+                        away_team_id,
+                        home_team.short_name(),
+                        away_team.short_name(),
+                        rng
+                    );
                     week.matchups_mut().push(matchup);
                 }
             }
-            self.rounds.push(week);
+            self.conference_brackets.entry(conference).or_default().push(week);
             Ok(())
+        }
+    }
+
+    /// Helper method for generating the winners' bracket first round matchups
+    fn gen_winners_first_round(&mut self, rng: &mut impl Rng) -> Result<(), String> {
+        // Ensure conditions are valid to generate conference wild card round
+        let num_teams = self.num_conferences();
+        if num_teams < 2 {
+            return Err(
+                format!(
+                    "Must contain at least 2 conferences for a winners bracket, got {}",
+                    num_teams
+                )
+            )
+        }
+        if !self.conference_brackets_complete() {
+            return Err(
+                String::from(
+                    "Cannot generate winners bracket, conference playoffs not complete"
+                )
+            )
+        }
+
+        if num_teams.is_power_of_two() {
+            // In this case, there is no wild-card round, this is a true first round
+            // Ensure the winners bracket has not yet started
+            if self.winners_bracket_started() {
+                return Err(
+                    String::from(
+                        "Cannot re-generate first round, winners bracket already started"
+                    )
+                )
+            }
+
+            // Clear the winners bracket if it already exists
+            self.winners_bracket = Vec::new();
+
+            // Match up the first round teams against one another
+            let first_round_matchups = num_teams.checked_div(2).ok_or(
+                String::from("Failed to calculate first round matchups")
+            )?;
+            let mut week = LeagueSeasonWeek::new();
+            for i in 0..first_round_matchups {
+                // Get the home and away teams by conference ID
+                let home_conf_id = i;
+                let away_conf_id = num_teams - (i + 1);
+                let home_team_id = self.conference_champion(home_conf_id)
+                    .ok_or_else(|| format!(
+                        "No conference champion found for conference {}",
+                        home_conf_id
+                    ))?;
+                let home_team = self.teams.get(home_team_id).unwrap();
+                let away_team_id = self.conference_champion(away_conf_id)
+                    .ok_or_else(|| format!(
+                        "No conference champion found for conference {}",
+                        away_conf_id
+                    ))?;
+                let away_team = self.teams.get(away_team_id).unwrap();
+
+                // Create the matchup and add to the week
+                let matchup = LeagueSeasonMatchup::new(
+                    home_team_id,
+                    away_team_id,
+                    home_team.short_name(),
+                    away_team.short_name(),
+                    rng
+                );
+                week.matchups_mut().push(matchup);
+            }
+
+            // Add the week to the conference bracket and return
+            self.winners_bracket.push(week);
+            Ok(())
+        } else {
+            // In this case, we need to determine the winners of the wild card round
+            // Ensure only the wild card round exists in the conference bracket
+            let rounds = self.winners_bracket.len();
+            if rounds > 1 {
+                return Err(
+                    format!(
+                        "Expected only 1 round in winners bracket, found {}",
+                        rounds
+                    )
+                );
+            }
+
+            // Get the seeds of the wild card winners from the conference bracket
+            let round = match self.winners_bracket.last() {
+                Some(r) => r,
+                None => return Err(String::from("Wild card round not found"))
+            };
+            let winner_ids: Vec<usize> = round.matchups().iter().map(
+                |x| x.winner().unwrap()
+            ).collect();
+            let num_winners = winner_ids.len();
+            let byes = self.winners_bracket_byes()?;
+
+            // Populate the round with matchups
+            let mut week = LeagueSeasonWeek::new();
+            if num_winners >= byes {
+                // Match up winners of middle-ranked matchups with byes
+                for i in 0..byes {
+                    let bye_conf_id = i;
+                    let winner_index = num_winners - (i + 1);
+                    let away_team_id = match winner_ids.get(winner_index) {
+                        Some(s) => *s,
+                        None => return Err(format!("No winner found at index {}", winner_index))
+                    };
+                    let home_team_id = self.conference_champion(bye_conf_id)
+                        .ok_or_else(|| format!(
+                            "No conference champion found for conference {}",
+                            bye_conf_id
+                        ))?;
+                    let home_team = self.teams.get(home_team_id).unwrap();
+                    let away_team = self.teams.get(away_team_id)
+                        .ok_or_else(|| format!(
+                            "No team found with ID {}",
+                            away_team_id
+                        ))?;
+
+                    // Create the matchup and add to the week
+                    let matchup = LeagueSeasonMatchup::new(
+                        home_team_id,
+                        away_team_id,
+                        home_team.short_name(),
+                        away_team.short_name(),
+                        rng
+                    );
+                    week.matchups_mut().push(matchup);
+                }
+
+                // Match up winners of higher/lower ranked matchups with each other
+                let diff_winners = num_winners - byes;
+                let diff_winner_matchups = diff_winners.checked_div(2).ok_or(
+                    String::from("Failed to calculate first round matchups")
+                )?;
+                for i in 0..diff_winner_matchups {
+                    let t1_id = match winner_ids.get(i) {
+                        Some(s) => *s,
+                        None => return Err(format!("No winner found at index {}", i))
+                    };
+                    let t1_seed = self.team_seed(t1_id)?;
+                    let t1_conference = self.team_conference(t1_id)?;
+                    let t2_index = diff_winners - (i + 1);
+                    let t2_id = match winner_ids.get(t2_index) {
+                        Some(s) => *s,
+                        None => return Err(format!("No winner found at index {}", t2_index))
+                    };
+                    let t2_seed = self.team_seed(t2_id)?;
+                    let t2_conference = self.team_conference(t2_id)?;
+                    // Lower seed gets home field advantage
+                    let (home_seed, home_conference, away_seed, away_conference) = if t1_seed < t2_seed {
+                        (t1_seed, t1_conference, t2_seed, t2_conference)
+                    } else {
+                        (t2_seed, t2_conference, t1_seed, t1_conference)
+                    };
+                    let (home_team_id, home_team) = self.teams.get_by_seed(home_conference, home_seed)
+                        .ok_or_else(|| format!(
+                            "No team found in conference {} with seed {}",
+                            home_conference,
+                            home_seed
+                        ))?;
+                    let (away_team_id, away_team) = self.teams.get_by_seed(away_conference, away_seed)
+                        .ok_or_else(|| format!(
+                            "No team found in conference {} with seed {}",
+                            away_conference,
+                            away_seed
+                        ))?;
+
+                    // Create the matchup and add to the week
+                    let matchup = LeagueSeasonMatchup::new(
+                        home_team_id,
+                        away_team_id,
+                        home_team.short_name(),
+                        away_team.short_name(),
+                        rng
+                    );
+                    week.matchups_mut().push(matchup);
+                }
+            } else {
+                // Match up highest-ranked byes against winners
+                for i in 0..num_winners {
+                    let bye_conf_id = i;
+                    let winner_index = num_winners - (i + 1);
+                    let away_team_id = match winner_ids.get(winner_index) {
+                        Some(s) => *s,
+                        None => return Err(format!("No winner found at index {}", winner_index))
+                    };
+                    let home_team_id = self.conference_champion(bye_conf_id)
+                        .ok_or_else(|| format!(
+                            "No conference champion found for conference {}",
+                            bye_conf_id
+                        ))?;
+                    let home_team = self.teams.get(home_team_id).unwrap();
+                    let away_team = self.teams.get(away_team_id)
+                        .ok_or_else(|| format!(
+                            "No team found with ID {}",
+                            away_team_id
+                        ))?;
+
+                    // Create the matchup and add to the week
+                    let matchup = LeagueSeasonMatchup::new(
+                        home_team_id,
+                        away_team_id,
+                        home_team.short_name(),
+                        away_team.short_name(),
+                        rng
+                    );
+                    week.matchups_mut().push(matchup);
+                }
+
+                // Match up lowest-ranked byes against each other
+                let diff_winners = byes - num_winners;
+                let diff_winner_matchups = diff_winners.checked_div(2).ok_or(
+                    String::from("Failed to calculate first round matchups")
+                )?;
+                for i in 0..diff_winner_matchups {
+                    let t1_conference = num_winners + i;
+                    let t1_id = self.conference_champion(t1_conference)
+                        .ok_or_else(|| format!(
+                            "No conference champion found for conference {}",
+                            t1_conference
+                        ))?;
+                    let t1_seed = self.team_seed(t1_id)?;
+                    let t2_conference = byes - (i + 1);
+                    let t2_id = self.conference_champion(t2_conference)
+                        .ok_or_else(|| format!(
+                            "No conference champion found for conference {}",
+                            t2_conference
+                        ))?;
+                    let t2_seed = self.team_seed(t2_id)?;
+                    // Lower seed gets home field advantage
+                    let (home_seed, home_conference, away_seed, away_conference) = if t1_seed < t2_seed {
+                        (t1_seed, t1_conference, t2_seed, t2_conference)
+                    } else {
+                        (t2_seed, t2_conference, t1_seed, t1_conference)
+                    };
+                    let (home_team_id, home_team) = self.teams.get_by_seed(home_conference, home_seed)
+                        .ok_or_else(|| format!(
+                            "No team found in conference {} with seed {}",
+                            home_conference,
+                            home_seed
+                        ))?;
+                    let (away_team_id, away_team) = self.teams.get_by_seed(away_conference, away_seed)
+                        .ok_or_else(|| format!(
+                            "No team found in conference {} with seed {}",
+                            away_conference,
+                            away_seed
+                        ))?;
+
+                    // Create the matchup and add to the week
+                    let matchup = LeagueSeasonMatchup::new(
+                        home_team_id,
+                        away_team_id,
+                        home_team.short_name(),
+                        away_team.short_name(),
+                        rng
+                    );
+                    week.matchups_mut().push(matchup);
+                }
+            }
+            self.winners_bracket.push(week);
+            Ok(())
+        }
+    }
+
+    /// Helper method for generating the next round of the conference playoffs
+    fn gen_next_conference_round(&mut self, conference: usize, rng: &mut impl Rng) -> Result<(), String> {
+        // Ensure there are enough teams in the conference (at least 2)
+        let num_teams = self.conference_teams(conference).len();
+        if num_teams < 2 {
+            return Err(format!("Playoffs must contain at least 2 teams, got {}", num_teams))
+        }
+        let first_round_teams = self.first_round_teams(Some(conference))?;
+        let bracket_len = self.conference_brackets.get(&conference).map(|b| b.len()).unwrap_or(0);
+        if bracket_len == 0 {
+            // Wild card round or first round
+            if first_round_teams != num_teams {
+                self.gen_conference_wild_card_round(conference, rng)
+            } else {
+                self.gen_conference_first_round(conference, rng)
+            }
+        } else {
+            // First round or later round
+            if bracket_len == 1 && first_round_teams != num_teams {
+                self.gen_conference_first_round(conference, rng)
+            } else {
+                // Get seeds of winners from previous round and ensure more than one
+                let round = match self.conference_brackets.get(&conference).and_then(|b| b.last()) {
+                    Some(r) => r,
+                    None => return Err(
+                        format!(
+                            "Previous round not found for conference {}",
+                            conference
+                        )
+                    )
+                };
+                let winner_seeds: Vec<usize> = round.matchups().iter().map(
+                    |x| self.team_seed(x.winner().unwrap()).unwrap()
+                ).collect();
+                let num_winners = winner_seeds.len();
+                if num_winners <= 1 {
+                    return Err(
+                        format!(
+                            "Cannot generate next round for conference {}, only {} teams remain",
+                            conference,
+                            num_winners
+                        )
+                    );
+                }
+                let next_round_matchups = num_winners.checked_div(2).ok_or(
+                    format!(
+                        "Failed to calculate next round matchups for conference {}",
+                        conference
+                    )
+                )?;
+
+                // Match up winners of previous round against each other (using default conference 0)
+                let mut week = LeagueSeasonWeek::new();
+                for i in 0..next_round_matchups {
+                    let t1_index = i * 2;
+                    let t1_seed = match winner_seeds.get(t1_index) {
+                        Some(s) => *s,
+                        None => return Err(format!("No winner found at index {}", t1_index))
+                    };
+                    let t2_seed = match winner_seeds.get(t1_index + 1) {
+                        Some(s) => *s,
+                        None => return Err(format!("No winner found at index {}", t1_index + 1))
+                    };
+
+                    // Get the home and away teams (lower seed gets home field)
+                    let (home_seed, away_seed) = if t1_seed < t2_seed {
+                        (t1_seed, t2_seed)
+                    } else {
+                        (t2_seed, t1_seed)
+                    };
+                    let (home_team_id, home_team) = self.teams.get_by_seed(conference, home_seed)
+                        .ok_or_else(|| format!(
+                            "No team found in conference {} with seed {}",
+                            conference,
+                            home_seed
+                        ))?;
+                    let (away_team_id, away_team) = self.teams.get_by_seed(conference, away_seed)
+                        .ok_or_else(|| format!(
+                            "No team found in conference {} with seed {}",
+                            conference,
+                            away_seed
+                        ))?;
+
+                    // Create the matchup and add to the week
+                    let matchup = LeagueSeasonMatchup::new(
+                        home_team_id,
+                        away_team_id,
+                        home_team.short_name(),
+                        away_team.short_name(),
+                        rng
+                    );
+                    week.matchups_mut().push(matchup);
+                }
+                self.conference_brackets.entry(conference).or_default().push(week);
+                Ok(())
+            }
+        }
+    }
+
+    /// Helper method for generating the next round for all conference brackets
+    fn gen_next_conference_rounds(&mut self, rng: &mut impl Rng) -> Result<(), String> {
+        let conference_ids: Vec<usize> = self.teams.conferences().copied().collect();
+        for conference in conference_ids {
+            self.gen_next_conference_round(conference, rng)?;
+        }
+        Ok(())
+    }
+
+    /// Helper method for generating the next round of the winners bracket
+    fn gen_next_winners_round(&mut self, rng: &mut impl Rng) -> Result<(), String> {
+        // Ensure there are enough conference champions
+        let num_teams = self.teams.num_conferences();
+        if num_teams < 2 {
+            return Err(
+                format!(
+                    "Winners bracket must contain at least 2 conference champions, got {}",
+                    num_teams
+                )
+            )
+        }
+
+        // Ensure the conference playoffs are complete
+        if !self.conference_brackets_complete() {
+            return Err(
+                String::from(
+                    "Cannot generate winners bracket: Conference playoffs not complete"
+                )
+            )
+        }
+
+        let first_round_teams = self.first_round_winners()?;
+        let bracket_len = self.winners_bracket.len();
+        if bracket_len == 0 {
+            // Wild card round or first round
+            if first_round_teams != num_teams {
+                self.gen_winners_wild_card_round(rng)
+            } else {
+                self.gen_winners_first_round(rng)
+            }
+        } else {
+            // First round or later round
+            if bracket_len == 1 && first_round_teams != num_teams {
+                self.gen_winners_first_round(rng)
+            } else {
+                // Get seeds of winners from previous round and ensure more than one
+                let round = match self.winners_bracket.last() {
+                    Some(r) => r,
+                    None => return Err(
+                        String::from(
+                            "Previous winners bracket round not found"
+                        )
+                    )
+                };
+                let winner_ids: Vec<usize> = round.matchups().iter().map(
+                    |x| x.winner().unwrap()
+                ).collect();
+                let num_winners = winner_ids.len();
+                if num_winners <= 1 {
+                    return Err(
+                        format!(
+                            "Cannot generate next round for winners bracket, only {} teams remain",
+                            num_winners
+                        )
+                    );
+                }
+                let next_round_matchups = num_winners.checked_div(2).ok_or(
+                    String::from(
+                        "Failed to calculate next round matchups for winners bracket"
+                    )
+                )?;
+
+                // Match up winners of previous round against each other
+                let mut week = LeagueSeasonWeek::new();
+                for i in 0..next_round_matchups {
+                    let t1_index = i * 2;
+                    let t1_id = match winner_ids.get(t1_index) {
+                        Some(s) => *s,
+                        None => return Err(format!("No winner found at index {}", t1_index))
+                    };
+                    let t1_seed = self.team_seed(t1_id)?;
+                    let t2_index = t1_index + 1;
+                    let t2_id = match winner_ids.get(t2_index) {
+                        Some(s) => *s,
+                        None => return Err(format!("No winner found at index {}", t2_index))
+                    };
+                    let t2_seed = self.team_seed(t2_id)?;
+                    // Get the home and away teams (lower seed gets home field)
+                    let (home_team_id, away_team_id) = if t1_seed < t2_seed {
+                        (t1_id, t2_id)
+                    } else {
+                        (t2_id, t1_id)
+                    };
+                    let home_team = self.teams.get(home_team_id).unwrap();
+                    let away_team = self.teams.get(away_team_id).unwrap();
+
+                    // Create the matchup and add to the week
+                    let matchup = LeagueSeasonMatchup::new(
+                        home_team_id,
+                        away_team_id,
+                        home_team.short_name(),
+                        away_team.short_name(),
+                        rng
+                    );
+                    week.matchups_mut().push(matchup);
+                }
+                self.winners_bracket.push(week);
+                Ok(())
+            }
+        }
+    }
+
+    /// Generate the next round of the playoffs
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffs;
+    ///
+    /// // Instantiate playoffs and add teams
+    /// let mut my_playoffs = LeagueSeasonPlayoffs::new();
+    /// let _ = my_playoffs.add_team(0, "A", Some(0));
+    /// let _ = my_playoffs.add_team(1, "B", Some(0));
+    /// let _ = my_playoffs.add_team(2, "C", Some(1));
+    /// let _ = my_playoffs.add_team(3, "D", Some(1));
+    /// let _ = my_playoffs.add_team(4, "E", Some(2));
+    /// let _ = my_playoffs.add_team(5, "F", Some(2));
+    ///
+    /// // Get the number of winners bracket first round byes
+    /// let mut rng = rand::thread_rng();
+    /// let res = my_playoffs.gen_next_playoff_round(&mut rng);
+    /// assert!(res.is_ok());
+    /// ```
+    pub fn gen_next_playoff_round(&mut self, rng: &mut impl Rng) -> Result<(), String> {
+        // Ensure playoffs are not already complete
+        if self.complete() {
+            return Err(
+                String::from(
+                    "Cannot generate next playoff round: Playoffs complete"
+                )
+            )
+        }
+
+        // Generate the next round of the playoffs
+        if self.is_conference_playoff() {
+            if self.conference_brackets_complete() {
+                self.gen_next_winners_round(rng)
+            } else {
+                self.gen_next_conference_rounds(rng)
+            }
+        } else {
+            self.gen_next_conference_rounds(rng)
+        }
+    }
+
+    /// Gets the championship matchup if it exists
+    ///
+    /// ### Example
+    /// ```
+    /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffs;
+    ///
+    /// // Create playoffs and add a team
+    /// let my_playoffs = LeagueSeasonPlayoffs::new();
+    /// let championship = my_playoffs.championship();
+    /// assert!(championship.is_none());
+    /// ```
+    pub fn championship(&self) -> Option<&LeagueSeasonMatchup> {
+        if self.is_conference_playoff() {
+            let conferences = self.teams.num_conferences();
+            if !self.winners_bracket_started() || 
+                self.winners_bracket.is_empty() ||
+                (
+                    self.winners_bracket.len() == 1 &&
+                    conferences > 2
+                ) {
+                return None;
+            }
+            if let Some(final_round) = self.winners_bracket.last() {
+                if final_round.matchups().len() != 1 {
+                    return None;
+                }
+                return final_round.matchups().first();
+            }
+            None
+        } else {
+            let bracket = self.conference_brackets.get(&0)?;
+            if bracket.is_empty() || (bracket.len() == 1 && self.teams.len() > 2) {
+                return None;
+            }
+            if let Some(final_round) = bracket.last() {
+                if final_round.matchups().len() != 1 {
+                    return None;
+                }
+                return final_round.matchups().first();
+            }
+            None
         }
     }
 
@@ -537,7 +2202,7 @@ impl LeagueSeasonPlayoffs {
     ///
     /// // Create playoffs and add a team
     /// let mut my_playoffs = LeagueSeasonPlayoffs::new();
-    /// let _ = my_playoffs.add_team(0, "ME");
+    /// let _ = my_playoffs.add_team(0, "ME", None);
     ///
     /// // Check if that team is in the championship
     /// let in_championship = my_playoffs.in_championship(0);
@@ -550,28 +2215,11 @@ impl LeagueSeasonPlayoffs {
             return Err(format!("Team {} not in playoffs", team_id));
         }
 
-        // Need at least one round for a championship
-        if self.rounds.is_empty() {
-            return Ok(false);
+        // Check if the team appeared in the championship matchup
+        match self.championship() {
+            Some(m) => Ok(*m.home_team() == team_id || *m.away_team() == team_id),
+            None => Ok(false)
         }
-
-        // Not championship if more than 2 teams but only 1 round
-        if self.rounds.len() == 1 && self.teams.len() > 2 {
-            return Ok(false);
-        }
-
-        // Get the final round
-        if let Some(final_round) = self.rounds.last() {
-            // Championship is the round with exactly 1 matchup
-            if final_round.matchups().len() == 1 {
-                if let Some(final_matchup) = final_round.matchups().first() {
-                    let team_in_championship = *final_matchup.home_team() == team_id ||
-                           *final_matchup.away_team() == team_id;
-                    return Ok(team_in_championship);
-                }
-            }
-        }
-        Ok(false)
     }
 
     /// Get the champion team ID if the playoffs are complete
@@ -584,18 +2232,10 @@ impl LeagueSeasonPlayoffs {
     /// assert!(my_playoffs.champion().is_none());
     /// ```
     pub fn champion(&self) -> Option<usize> {
-        // If playoffs are not complete, there is no champion
-        if !self.complete() {
-            return None;
+        match self.championship() {
+            Some(m) => m.winner(),
+            None => None
         }
-
-        // Get the final round's single matchup and return the winner
-        if let Some(final_round) = self.rounds.last() {
-            if let Some(final_matchup) = final_round.matchups().first() {
-                return final_matchup.winner();
-            }
-        }
-        None
     }
 
     /// Compute a team's playoff record
@@ -607,7 +2247,7 @@ impl LeagueSeasonPlayoffs {
     ///
     /// // Create playoffs and add a team
     /// let mut my_playoffs = LeagueSeasonPlayoffs::new();
-    /// let _ = my_playoffs.add_team(0, "ME");
+    /// let _ = my_playoffs.add_team(0, "ME", None);
     ///
     /// // Get that team's record
     /// let record = my_playoffs.record(0);
@@ -621,8 +2261,11 @@ impl LeagueSeasonPlayoffs {
         }
         let mut record = LeagueTeamRecord::new();
 
-        // Calculate the team's playoff record
-        for round in self.rounds.iter() {
+        // Calculate the team's playoff record across all brackets
+        let all_rounds = self.conference_brackets.values().flatten()
+            .chain(self.winners_bracket.iter());
+
+        for round in all_rounds {
             for matchup in round.matchups().iter() {
                 // Check if this team participated in the matchup
                 if *matchup.home_team() != team_id && *matchup.away_team() != team_id {
@@ -640,105 +2283,5 @@ impl LeagueSeasonPlayoffs {
             }
         }
         Ok(record)
-    }
-
-    /// Generate the next round of the playoffs
-    ///
-    /// ### Example
-    /// ```
-    /// use fbsim_core::league::season::playoffs::LeagueSeasonPlayoffs;
-    ///
-    /// // Instantiate playoffs and add teams
-    /// let mut my_playoffs = LeagueSeasonPlayoffs::new();
-    /// let _ = my_playoffs.add_team(0, "ME");
-    /// let _ = my_playoffs.add_team(1, "YOU");
-    /// let _ = my_playoffs.add_team(2, "THEM");
-    ///
-    /// // Generate the next round of the playoffs
-    /// let mut rng = rand::thread_rng();
-    /// let res = my_playoffs.gen_next_round(&mut rng);
-    /// assert!(res.is_ok());
-    /// ```
-    pub fn gen_next_round(&mut self, rng: &mut impl Rng) -> Result<(), String> {
-        // Ensure there are enough teams (at least 2)
-        let num_teams = self.teams.len();
-        if num_teams < 2 {
-            return Err(format!("Playoffs must contain at least 2 teams, got {}", num_teams))
-        }
-
-        let first_round_teams = self.first_round_teams()?;
-        if self.rounds.is_empty() {
-            // Wild card round or first round
-            if first_round_teams != num_teams {
-                self.gen_wild_card_round(rng)
-            } else {
-                self.gen_first_round(rng)
-            }
-        } else {
-            // First round or later round
-            if self.rounds.len() == 1 && first_round_teams != num_teams {
-                self.gen_first_round(rng)
-            } else {
-                // Get seeds of winners from previous round and ensure more than one
-                let round = match self.rounds.last() {
-                    Some(r) => r,
-                    None => return Err(String::from("Previous round not found"))
-                };
-                let winner_seeds: Vec<usize> = round.matchups().iter().map(
-                    |x| self.team_seed(x.winner().unwrap()).unwrap()
-                ).collect();
-                let num_winners = winner_seeds.len();
-                if num_winners <= 1 {
-                    return Err(format!("Cannot generate next round, only {} teams remain", num_winners));
-                }
-                let next_round_matchups = num_winners.checked_div(2).ok_or(
-                    String::from("Failed to calculate next round matchups")
-                )?;
-
-                // Match up winners of previous round against each other
-                let mut week = LeagueSeasonWeek::new();
-                for i in 0..next_round_matchups {
-                    let t1_index = i * 2;
-                    let t1_seed = match winner_seeds.get(t1_index) {
-                        Some(s) => *s,
-                        None => return Err(format!("No winner found at index {}", t1_index))
-                    };
-                    let t2_seed = match winner_seeds.get(t1_index + 1) {
-                        Some(s) => *s,
-                        None => return Err(format!("No winner found at index {}", t1_index + 1))
-                    };
-
-                    // Get the home and away teams (lower seed gets home field)
-                    let (home_id, home_name) = if t1_seed < t2_seed {
-                        match self.teams.get(&t1_seed) {
-                            Some(t) => t,
-                            None => return Err(format!("No team found with seed {}", t1_seed))
-                        }
-                    } else {
-                        match self.teams.get(&t2_seed) {
-                            Some(t) => t,
-                            None => return Err(format!("No team found with seed {}", t2_seed))
-                        }
-                    };
-                    let (away_id, away_name) = if t1_seed < t2_seed {
-                        match self.teams.get(&t2_seed) {
-                            Some(t) => t,
-                            None => return Err(format!("No team found with seed {}", t2_seed))
-                        }
-                    } else {
-                        match self.teams.get(&t1_seed) {
-                            Some(t) => t,
-                            None => return Err(format!("No team found with seed {}", t1_seed))
-                        }
-                    };
-
-                    // Create the matchup and add to the week
-                    let matchup = LeagueSeasonMatchup::new(*home_id, *away_id, home_name, away_name, rng);
-                    week.matchups_mut().push(matchup);
-                }
-                self.rounds.push(week);
-                Ok(())
-            }
-        }
     }
 }

--- a/src/league/season/playoffs/picture.rs
+++ b/src/league/season/playoffs/picture.rs
@@ -232,6 +232,20 @@ impl RecordBounds {
     }
 }
 
+/// # `PlayoffPictureOptions` struct
+///
+/// Options for configuring how the playoff picture is generated
+#[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[derive(Clone, PartialEq, Debug, Default, Serialize, Deserialize)]
+pub struct PlayoffPictureOptions {
+    /// If `Some(true)`, force conference-based playoff picture.
+    /// If `Some(false)`, force flat (non-conference) playoff picture.
+    /// If `None`, auto-detect: use conferences if the season has multiple conferences.
+    pub by_conference: Option<bool>,
+    /// If true, division winners are guaranteed a playoff berth (conference mode only)
+    pub division_winners_guaranteed: bool,
+}
+
 /// # `PlayoffPicture` struct
 ///
 /// Represents the complete playoff picture for a season, showing the
@@ -247,9 +261,16 @@ pub struct PlayoffPicture {
 impl PlayoffPicture {
     /// Create a playoff picture from a season
     ///
+    /// When the season has multiple conferences, the playoff picture is organized
+    /// by conference by default (with `num_playoff_teams` interpreted as the number
+    /// of playoff teams *per conference*). This behavior can be overridden via
+    /// `PlayoffPictureOptions`.
+    ///
     /// ### Arguments
     /// * `season` - The league season to analyze
-    /// * `num_playoff_teams` - Number of teams that will make the playoffs
+    /// * `num_playoff_teams` - Number of teams that make the playoffs. In conference
+    ///   mode this is the number of teams *per conference*.
+    /// * `options` - Optional configuration; pass `None` for defaults
     ///
     /// ### Returns
     /// * `Ok(PlayoffPicture)` - The current playoff picture
@@ -274,10 +295,34 @@ impl PlayoffPicture {
     /// my_league_season.generate_schedule(LeagueSeasonScheduleOptions::new(), &mut rng);
     ///
     /// // Get the playoff picture for a 2-team playoff
-    /// let picture = PlayoffPicture::from_season(&my_league_season, 2);
+    /// let picture = PlayoffPicture::from_season(&my_league_season, 2, None);
     /// assert!(picture.is_ok());
     /// ```
-    pub fn from_season(season: &LeagueSeason, num_playoff_teams: usize) -> Result<Self, String> {
+    pub fn from_season(
+        season: &LeagueSeason,
+        num_playoff_teams: usize,
+        options: Option<PlayoffPictureOptions>,
+    ) -> Result<Self, String> {
+        let opts = options.unwrap_or_default();
+
+        let use_conferences = match opts.by_conference {
+            Some(v) => v,
+            None => season.conferences().len() > 1,
+        };
+
+        if use_conferences {
+            Self::conference_playoff_picture(
+                season,
+                num_playoff_teams,
+                opts.division_winners_guaranteed,
+            )
+        } else {
+            Self::non_conference_playoff_picture(season, num_playoff_teams)
+        }
+    }
+
+    /// Build a playoff picture using overall league standings (no conference separation)
+    fn non_conference_playoff_picture(season: &LeagueSeason, num_playoff_teams: usize) -> Result<Self, String> {
         let total_teams = season.teams().len();
 
         // Validate parameters
@@ -372,6 +417,173 @@ impl PlayoffPicture {
         Ok(PlayoffPicture {
             num_playoff_teams,
             entries,
+            games_remaining_in_season,
+        })
+    }
+
+    /// Build a playoff picture organized by conference
+    fn conference_playoff_picture(
+        season: &LeagueSeason,
+        playoff_teams_per_conference: usize,
+        division_winners_guaranteed: bool,
+    ) -> Result<Self, String> {
+        // Validate that we have conferences
+        if season.conferences().is_empty() {
+            return Err("Season has no conferences defined".to_string());
+        }
+
+        if season.weeks().is_empty() {
+            return Err("Season has no schedule".to_string());
+        }
+
+        if playoff_teams_per_conference == 0 {
+            return Err("Number of playoff teams per conference must be at least 1".to_string());
+        }
+
+        // Validate that playoff_teams_per_conference does not exceed the
+        // smallest conference size
+        let min_conference_size = season
+            .conferences()
+            .iter()
+            .map(|c| c.num_teams())
+            .min()
+            .unwrap_or(0);
+
+        if playoff_teams_per_conference > min_conference_size {
+            return Err(format!(
+                "Playoff teams per conference ({}) exceeds the smallest conference size ({})",
+                playoff_teams_per_conference, min_conference_size
+            ));
+        }
+
+        let num_conferences = season.conferences().len();
+        let total_playoff_teams = playoff_teams_per_conference * num_conferences;
+
+        // Compute remaining games for each team
+        let mut team_remaining_games: BTreeMap<usize, usize> = BTreeMap::new();
+        let mut games_remaining_in_season = 0;
+
+        for week in season.weeks().iter() {
+            for matchup in week.matchups().iter() {
+                if !matchup.context().game_over() {
+                    games_remaining_in_season += 1;
+                    *team_remaining_games.entry(*matchup.home_team()).or_insert(0) += 1;
+                    *team_remaining_games.entry(*matchup.away_team()).or_insert(0) += 1;
+                }
+            }
+        }
+
+        let total_games = season.weeks().len();
+        let mut all_entries = Vec::new();
+
+        // Process each conference
+        for conf_index in 0..num_conferences {
+            let conference = season.conferences().get(conf_index)
+                .ok_or_else(|| format!("Conference {} not found", conf_index))?;
+
+            // Get conference standings
+            let conf_standings = season.conference_standings(conf_index)?;
+
+            // Determine division winners
+            let mut division_winners: Vec<usize> = Vec::new();
+            if division_winners_guaranteed {
+                for (div_id, _) in conference.divisions().iter().enumerate() {
+                    let div_standings = season.division_standings(conf_index, div_id)?;
+                    if let Some((winner_id, _)) = div_standings.first() {
+                        division_winners.push(*winner_id);
+                    }
+                }
+            }
+
+            // Determine playoff teams for this conference
+            let mut conf_playoff_teams: Vec<usize> = Vec::new();
+
+            // First, add all division winners (if guaranteed)
+            for &winner in &division_winners {
+                if conf_playoff_teams.len() < playoff_teams_per_conference {
+                    conf_playoff_teams.push(winner);
+                }
+            }
+
+            // Fill remaining spots with wild cards (best records not already in)
+            for (team_id, _record) in conf_standings.iter() {
+                if conf_playoff_teams.len() >= playoff_teams_per_conference {
+                    break;
+                }
+                if !conf_playoff_teams.contains(team_id) {
+                    conf_playoff_teams.push(*team_id);
+                }
+            }
+
+            // Compute record bounds for conference teams
+            let bounds: Vec<RecordBounds> = conf_standings
+                .iter()
+                .map(|(team_id, record)| {
+                    let remaining = *team_remaining_games.get(team_id).unwrap_or(&0);
+                    RecordBounds::from_record(*team_id, record, remaining, total_games)
+                })
+                .collect();
+
+            // Build entries for each team in the conference
+            for (position, (team_id, record)) in conf_standings.iter().enumerate() {
+                let team_name = season
+                    .teams()
+                    .get(team_id)
+                    .map(|t| t.name().to_string())
+                    .unwrap_or_else(|| format!("Team {}", team_id));
+
+                let remaining = *team_remaining_games.get(team_id).unwrap_or(&0);
+                let in_playoff_position = position < playoff_teams_per_conference;
+                let is_division_winner = division_winners.contains(team_id);
+
+                // Calculate games back (within conference)
+                let games_back = if in_playoff_position {
+                    0.0
+                } else {
+                    Self::compute_games_back(&conf_standings, position, playoff_teams_per_conference)
+                };
+
+                // Determine status (within conference context)
+                let status = Self::compute_status(
+                    *team_id,
+                    position,
+                    &bounds,
+                    playoff_teams_per_conference,
+                );
+
+                // Calculate magic number
+                let magic_number = if matches!(status, PlayoffStatus::Eliminated) {
+                    None
+                } else {
+                    Self::compute_magic_number(*team_id, &bounds, playoff_teams_per_conference)
+                };
+
+                // Adjust status based on division winner guarantee
+                let final_status = if is_division_winner && division_winners_guaranteed {
+                    // Division winners get special consideration
+                    match &status {
+                        PlayoffStatus::Eliminated => status, // Can't be eliminated if div winner guaranteed
+                        _ => status,
+                    }
+                } else {
+                    status
+                };
+
+                all_entries.push(PlayoffPictureEntry {
+                    team_id: *team_id,
+                    team_name,
+                    current_record: record.clone(),
+                    status: final_status,
+                    games_back,
+                    remaining_games: remaining,
+                    magic_number,
+                });
+            }
+        }
+
+        Ok(PlayoffPicture {
+            num_playoff_teams: total_playoff_teams,
+            entries: all_entries,
             games_remaining_in_season,
         })
     }
@@ -658,7 +870,7 @@ impl PlayoffPicture {
     /// my_league_season.generate_schedule(LeagueSeasonScheduleOptions::new(), &mut rng);
     ///
     /// // Get the playoff picture for a 2-team playoff
-    /// let picture = PlayoffPicture::from_season(&my_league_season, 2).unwrap();
+    /// let picture = PlayoffPicture::from_season(&my_league_season, 2, None).unwrap();
     /// assert!(picture.num_playoff_teams() == 2);
     /// ```
     pub fn num_playoff_teams(&self) -> usize {
@@ -686,7 +898,7 @@ impl PlayoffPicture {
     /// my_league_season.generate_schedule(LeagueSeasonScheduleOptions::new(), &mut rng);
     ///
     /// // Get the playoff picture for a 2-team playoff
-    /// let picture = PlayoffPicture::from_season(&my_league_season, 2).unwrap();
+    /// let picture = PlayoffPicture::from_season(&my_league_season, 2, None).unwrap();
     /// let entries = picture.entries();
     /// ```
     pub fn entries(&self) -> &Vec<PlayoffPictureEntry> {
@@ -714,7 +926,7 @@ impl PlayoffPicture {
     /// my_league_season.generate_schedule(LeagueSeasonScheduleOptions::new(), &mut rng);
     ///
     /// // Get the playoff picture for a 2-team playoff
-    /// let picture = PlayoffPicture::from_season(&my_league_season, 2).unwrap();
+    /// let picture = PlayoffPicture::from_season(&my_league_season, 2, None).unwrap();
     /// let entries = picture.entries();
     /// ```
     pub fn games_remaining_in_season(&self) -> usize {
@@ -742,7 +954,7 @@ impl PlayoffPicture {
     /// my_league_season.generate_schedule(LeagueSeasonScheduleOptions::new(), &mut rng);
     ///
     /// // Get the playoff picture for a 2-team playoff
-    /// let picture = PlayoffPicture::from_season(&my_league_season, 2).unwrap();
+    /// let picture = PlayoffPicture::from_season(&my_league_season, 2, None).unwrap();
     /// let playoff_teams = picture.playoff_teams();
     /// ```
     pub fn playoff_teams(&self) -> Vec<&PlayoffPictureEntry> {
@@ -778,7 +990,7 @@ impl PlayoffPicture {
     /// my_league_season.generate_schedule(LeagueSeasonScheduleOptions::new(), &mut rng);
     ///
     /// // Get the playoff picture for a 2-team playoff
-    /// let picture = PlayoffPicture::from_season(&my_league_season, 2).unwrap();
+    /// let picture = PlayoffPicture::from_season(&my_league_season, 2, None).unwrap();
     /// let clinched_teams = picture.clinched_teams();
     /// ```
     pub fn clinched_teams(&self) -> Vec<&PlayoffPictureEntry> {
@@ -812,7 +1024,7 @@ impl PlayoffPicture {
     /// my_league_season.generate_schedule(LeagueSeasonScheduleOptions::new(), &mut rng);
     ///
     /// // Get the playoff picture for a 2-team playoff
-    /// let picture = PlayoffPicture::from_season(&my_league_season, 2).unwrap();
+    /// let picture = PlayoffPicture::from_season(&my_league_season, 2, None).unwrap();
     /// let in_the_hunt = picture.in_the_hunt();
     /// ```
     pub fn in_the_hunt(&self) -> Vec<&PlayoffPictureEntry> {
@@ -843,7 +1055,7 @@ impl PlayoffPicture {
     /// my_league_season.generate_schedule(LeagueSeasonScheduleOptions::new(), &mut rng);
     ///
     /// // Get the playoff picture for a 2-team playoff
-    /// let picture = PlayoffPicture::from_season(&my_league_season, 2).unwrap();
+    /// let picture = PlayoffPicture::from_season(&my_league_season, 2, None).unwrap();
     /// let eliminated_teams = picture.eliminated_teams();
     /// ```
     pub fn eliminated_teams(&self) -> Vec<&PlayoffPictureEntry> {
@@ -874,7 +1086,7 @@ impl PlayoffPicture {
     /// my_league_season.generate_schedule(LeagueSeasonScheduleOptions::new(), &mut rng);
     ///
     /// // Get the playoff picture for a 2-team playoff
-    /// let picture = PlayoffPicture::from_season(&my_league_season, 2).unwrap();
+    /// let picture = PlayoffPicture::from_season(&my_league_season, 2, None).unwrap();
     /// let team_status = picture.team_status(3);
     /// assert!(team_status.is_some());
     /// ```
@@ -961,7 +1173,7 @@ mod tests {
         season.generate_schedule(LeagueSeasonScheduleOptions::new(), &mut rng).unwrap();
 
         // Get playoff picture for 2-team playoffs
-        let picture = PlayoffPicture::from_season(&season, 2).unwrap();
+        let picture = PlayoffPicture::from_season(&season, 2, None).unwrap();
 
         // All teams should have games remaining
         assert!(picture.games_remaining_in_season() > 0);
@@ -1003,7 +1215,7 @@ mod tests {
         }
 
         // Get playoff picture
-        let picture = PlayoffPicture::from_season(&season, 2).unwrap();
+        let picture = PlayoffPicture::from_season(&season, 2, None).unwrap();
 
         // Should have some games remaining
         assert!(picture.games_remaining_in_season() > 0);
@@ -1037,7 +1249,7 @@ mod tests {
         season.sim_regular_season(&mut rng).unwrap();
 
         // Get playoff picture
-        let picture = PlayoffPicture::from_season(&season, 2).unwrap();
+        let picture = PlayoffPicture::from_season(&season, 2, None).unwrap();
 
         // No games remaining
         assert_eq!(picture.games_remaining_in_season(), 0);
@@ -1071,11 +1283,11 @@ mod tests {
         season.generate_schedule(LeagueSeasonScheduleOptions::new(), &mut rng).unwrap();
 
         // Test: num_playoff_teams = 0 should fail
-        let result = PlayoffPicture::from_season(&season, 0);
+        let result = PlayoffPicture::from_season(&season, 0, None);
         assert!(result.is_err());
 
         // Test: num_playoff_teams > total teams should fail
-        let result = PlayoffPicture::from_season(&season, 5);
+        let result = PlayoffPicture::from_season(&season, 5, None);
         assert!(result.is_err());
     }
 
@@ -1090,7 +1302,7 @@ mod tests {
         season.add_team(1, FootballTeam::new()).unwrap();
 
         // Should fail because no schedule
-        let result = PlayoffPicture::from_season(&season, 1);
+        let result = PlayoffPicture::from_season(&season, 1, None);
         assert!(result.is_err());
     }
 
@@ -1111,7 +1323,7 @@ mod tests {
         season.generate_schedule(LeagueSeasonScheduleOptions::new(), &mut rng).unwrap();
 
         // Get playoff picture
-        let picture = PlayoffPicture::from_season(&season, 2).unwrap();
+        let picture = PlayoffPicture::from_season(&season, 2, None).unwrap();
 
         // Should be able to look up each team
         for id in 0..4 {
@@ -1145,7 +1357,7 @@ mod tests {
             season.sim_week(week_idx, &mut rng).unwrap();
         }
 
-        let picture = PlayoffPicture::from_season(&season, 2).unwrap();
+        let picture = PlayoffPicture::from_season(&season, 2, None).unwrap();
 
         // Teams in playoff position should have games_back = 0
         for entry in picture.playoff_teams() {


### PR DESCRIPTION
Cherry-pick of PR:
- https://github.com/whatsacomputertho/fbsim-core/pull/83

For reference, see:
- https://github.com/whatsacomputertho/fbsim-core/issues/26

Includes commits:
* feat(league): add conferences and divisions
* refac(playoffs): improve internal data structures for conference-based playoffs
* feat(league): begin addressing feedback, multi-conference playoffs
* feat(league): continue refactoring multi-conference playoffs
* feat(playoffs): refactor championship and champion methods
* feat(league): continue to address feedback
* feat(league): multi-conference playoff gen and sim
* feat(validation): add raw struct validation to new league types
* feat(validation): add playoff and schedule gen runtime validations
* feat(validation): add conference validation to league season
* feat(playoffs): add winners bracket play-by-play sim
* fix(duplicate): add run-time validation for duplicate conf+div teams
* fix(lint): resolve failing lint errors