### PR TITLE
feat(wasm): add wasm module build & publish

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install Dependencies
+        run: |
+          make build-dependencies
       - name: Build Crate
         run: |
           BUILD_ARGS="--verbose" make build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,15 +6,37 @@ on:
 
 permissions:
   contents: write
+  pages: write
+  id-token: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install Dependencies
+        run: |
+          make build-dependencies
+      - name: Build Crate
+        run: |
+          BUILD_ARGS="--verbose" make build
       - name: Release Distribution
         if: github.event.release.prerelease == false
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           RELEASE_ARGS="--verbose" make release
+      - name: Install Dev Dependencies
+        run: |
+          npm install
+      - name: Generate JS Documentation
+        run: |
+          npm run docs:generate
+      - name: Upload Pages Artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs-js
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /target
 .env
+/pkg-node
+/pkg-web
+/pkg
+/docs-js

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,9 +115,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -145,6 +145,16 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -201,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
 ]
@@ -288,15 +298,25 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 name = "fbsim-core"
 version = "1.0.0-beta.1"
 dependencies = [
+ "bytes",
  "chrono",
+ "console_error_panic_hook",
+ "getrandom",
+ "js-sys",
  "lazy_static",
  "rand",
  "rand_distr",
  "rocket_okapi",
  "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
  "statrs",
+ "time",
  "tokio",
  "tracing-subscriber",
+ "tsify-next",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -404,8 +424,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -413,6 +435,19 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "gloo-utils"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
 
 [[package]]
 name = "hashbrown"
@@ -678,6 +713,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "mio"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,9 +799,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-integer"
@@ -1169,6 +1214,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schemars"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,18 +1261,39 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1418,30 +1493,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1449,9 +1524,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
  "libc",
@@ -1606,6 +1681,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tsify-next"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d0f2208feeb5f7a6edb15a2389c14cd42480ef6417318316bb866da5806a61d"
+dependencies = [
+ "gloo-utils",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "tsify-next-macros",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "tsify-next-macros"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81253930d0d388a3ab8fa4ae56da9973ab171ef833d1be2e9080fc3ce502bd6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.92",
+]
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1655,6 +1756,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1696,6 +1807,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1728,6 +1852,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-test"
+version = "0.3.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c8d5e33ca3b6d9fa3b4676d774c5778031d27a578c2b007f905acf816152c3"
+dependencies = [
+ "js-sys",
+ "minicov",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17d5042cc5fa009658f9a7333ef24291b1291a25b6382dd68862a7f3b969f69b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.92",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wide"
 version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1735,6 +1893,15 @@ checksum = "41b5576b9a81633f3e8df296ce0063042a73507636cbe956c61133dd7034ab22"
 dependencies = [
  "bytemuck",
  "safe_arch",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,16 +13,52 @@ categories = ["games","simulation"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 chrono = "0.4.42"
 lazy_static = "1.5.0"
-rand = "0.8.5"
+rand = { version = "0.8.5", features = ["small_rng"] }
 rand_distr = "0.4.3"
-rocket_okapi = { version = "0.9.0", features = ["swagger"], optional = true }
 serde = { version = "1.0.217", features = ["derive"] }
+serde_json = "1.0"
 statrs = "0.18.0"
-tokio = "1.48.0" # Overrides rocket dependency
-tracing-subscriber = "0.3.22" # Overrides rocket dependency
+
+# Rocket dependencies (optional)
+rocket_okapi = { version = "0.9.0", features = ["swagger"], optional = true }
+time = { version = "0.3.47", optional = true } # Overrides rocket dependency
+tokio = { version = "1.49.0", optional = true } # Overrides rocket dependency
+tracing-subscriber = { version = "0.3.22", optional = true } # Overrides rocket dependency
+bytes = { version = "1.11.1", optional = true } # Overrides rocket dependency
+
+# WASM dependencies (optional)
+wasm-bindgen = { version = "0.2", optional = true }
+js-sys = { version = "0.3", optional = true }
+serde-wasm-bindgen = { version = "0.6", optional = true }
+getrandom = { version = "0.2", features = ["js"], optional = true }
+console_error_panic_hook = { version = "0.1", optional = true }
+tsify-next = { version = "0.5", optional = true, features = ["js"] }
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
 
 [features]
-rocket_okapi = ["dep:rocket_okapi"]
+rocket_okapi = [
+    "dep:rocket_okapi",
+    "dep:tokio",
+    "dep:tracing-subscriber",
+    "dep:bytes"
+]
+wasm = [
+    "dep:wasm-bindgen",
+    "dep:js-sys",
+    "dep:serde-wasm-bindgen",
+    "dep:getrandom",
+    "dep:console_error_panic_hook",
+    "dep:tsify-next",
+]
+
+[profile.release]
+lto = true
+opt-level = "s"

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,19 @@ BUILD_ARGS ?= --release
 RELEASE_ARGS ?= --dry-run
 LINT_ARGS ?= --all-targets --all-features -- -D warnings
 
+build-dependencies:
+	cargo install wasm-pack
+
 build:
 	cargo build $(BUILD_ARGS)
+	npm run build
 
 test:
 	cargo test
 
 release:
 	cargo publish $(RELEASE_ARGS)
+	npm publish
 
 lint:
 	cargo clippy $(LINT_ARGS)
@@ -19,3 +24,6 @@ sec-dependencies:
 
 sec:
 	cargo audit
+
+docs-js:
+	npm run docs

--- a/README.md
+++ b/README.md
@@ -4,19 +4,23 @@
 
 > A library for american football simulation
 
-**Docs**: https://docs.rs/fbsim-core/latest/fbsim_core/
+**Rust Docs**: https://docs.rs/fbsim-core/latest/fbsim_core/
 
 **Contributing**: [CONTRIBUTING.md](https://github.com/whatsacomputertho/fbsim-core/blob/main/CONTRIBUTING.md)
 
 ## Overview
 
-Provides utilities for simulating american football games and leagues. It is based on various statistical models derived in repositories
+Provides utilities for simulating american football games and leagues. The core library is written in Rust; it also compiles into a WebAssembly module for use in JavaScript and TypeScript projects. It is based on various statistical models derived in repositories
 - [whatsacomputertho/nfl-pbp-eda](https://github.com/whatsacomputertho/nfl-pbp-eda)
 - [whatsacomputertho/fbdb-boxscore-eda](https://github.com/whatsacomputertho/fbdb-boxscore-eda)
 
-## Play-by-play sim
+## Example
 
-Here is a quick example of simulating a play-by-play game between two teams.
+Below is a quick example of running a play-by-play football simulation using `fbsim-core`. It includes equivalent examples, one in Rust using the `fbsim-core` Rust crate, the other in JavaScript using the `fbsim-core` NPM package.
+
+### Rust
+
+Here is a quick example of simulating a play-by-play game between two teams in Rust.
 
 ```rust
 use fbsim_core::game::context::GameContext;
@@ -38,31 +42,51 @@ println!("{}", game);
 println!("{} Game over", next_context);
 ```
 
-## Final score sim
+### JavaScript & TypeScript
 
-There is also a less in-depth simulator that produces a final score given two teams. Here is a quick example of its usage.
+The same play-by-play simulation is available in JavaScript and TypeScript via WebAssembly.
 
-```rust
-use fbsim_core::game::score::FinalScoreSimulator;
-use fbsim_core::team::FootballTeam;
+```typescript
+import init, {
+  FootballTeam,
+  Game,
+  GameSimulator,
+  Rng,
+  createGameContext,
+} from "@whatsacomputertho/fbsim-core";
 
-// Instantiate the home and away teams
-let home_team = FootballTeam::new();
-let away_team = FootballTeam::new();
+// Initialize the WASM module
+await init();
 
-// Instantiate the rng, simulator, and simulate the game
-let mut rng = rand::thread_rng();
-let sim = FinalScoreSimulator::new();
-let final_score = sim.sim(&home_team, &away_team, &mut rng).unwrap();
+// Create teams with overall offensive & defensive ratings
+const home = new FootballTeam();
+const away = new FootballTeam();
 
-// Print the final score
-println!("{}", final_score);
+// Set up game state
+const rng = new Rng();
+const simulator = new GameSimulator();
+const game = new Game();
+let ctx = createGameContext();
+
+// Simulate play-by-play and print the game log
+while (!game.complete) {
+  ctx = simulator.simPlay(home, away, ctx, game, rng);
+  const play = game.getLatestPlay();
+  console.log(play.description);
+}
+console.log("Game Over");
 ```
 
 ## Installing
 
-To add the package to your project, run the following from your project directory.
+### Rust
 
 ```sh
 cargo add fbsim-core
+```
+
+### JavaScript & TypeScript
+
+```sh
+npm install @whatsacomputertho/fbsim-core
 ```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@whatsacomputertho/fbsim-core",
+  "version": "1.0.0-beta.1",
+  "description": "A library for american football simulation",
+  "main": "pkg/node/fbsim_core.js",
+  "module": "pkg/web/fbsim_core.js",
+  "types": "pkg/web/fbsim_core.d.ts",
+  "exports": {
+    ".": {
+      "node": {
+        "import": "./pkg/node/fbsim_core.js",
+        "require": "./pkg/node/fbsim_core.js",
+        "types": "./pkg/node/fbsim_core.d.ts"
+      },
+      "default": {
+        "import": "./pkg/web/fbsim_core.js",
+        "types": "./pkg/web/fbsim_core.d.ts"
+      }
+    },
+    "./web": {
+      "import": "./pkg/web/fbsim_core.js",
+      "types": "./pkg/web/fbsim_core.d.ts"
+    },
+    "./node": {
+      "import": "./pkg/node/fbsim_core.js",
+      "require": "./pkg/node/fbsim_core.js",
+      "types": "./pkg/node/fbsim_core.d.ts"
+    }
+  },
+  "files": [
+    "pkg/web/",
+    "pkg/node/"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/whatsacomputertho/fbsim-core"
+  },
+  "keywords": [
+    "football",
+    "simulation",
+    "wasm",
+    "rust",
+    "sports",
+    "game"
+  ],
+  "author": "whatsacomputertho",
+  "license": "GPL-3.0",
+  "homepage": "https://github.com/whatsacomputertho/fbsim-core",
+  "bugs": {
+    "url": "https://github.com/whatsacomputertho/fbsim-core/issues"
+  },
+  "scripts": {
+    "build": "npm run build:web && npm run build:node",
+    "build:web": "wasm-pack build --target web --out-dir pkg/web --features wasm",
+    "build:node": "wasm-pack build --target nodejs --out-dir pkg/node --features wasm",
+    "test": "wasm-pack test --node --features wasm",
+    "clean": "rm -rf pkg-web ./pkg",
+    "prepublishOnly": "npm run build",
+    "docs": "npm run build && node scripts/inject-jsdoc.mjs && npx typedoc",
+    "docs:generate": "node scripts/inject-jsdoc.mjs && npx typedoc"
+  },
+  "devDependencies": {
+    "typedoc": "^0.27.0"
+  },
+  "sideEffects": false
+}

--- a/scripts/inject-jsdoc.mjs
+++ b/scripts/inject-jsdoc.mjs
@@ -1,0 +1,306 @@
+#!/usr/bin/env node
+
+/**
+ * inject-jsdoc.mjs
+ *
+ * Extracts `///` doc comments from Rust source files for Tsify-derived types
+ * and injects them as JSDoc comments into the generated `.d.ts` files.
+ *
+ * wasm-bindgen preserves doc comments for opaque `#[wasm_bindgen]` classes,
+ * but Tsify-generated interfaces/enums/type aliases do not get JSDoc in the
+ * output `.d.ts`. This script bridges that gap.
+ *
+ * Usage:
+ *   node scripts/inject-jsdoc.mjs
+ *
+ * Expects `pkg/web/fbsim_core.d.ts` and `pkg/node/fbsim_core.d.ts` to exist.
+ */
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
+import { join, extname } from "node:path";
+
+const ROOT = new URL("..", import.meta.url).pathname.replace(/^\/([A-Z]:)/, "$1");
+const SRC_DIR = join(ROOT, "src");
+const DTS_PATHS = [
+  join(ROOT, "pkg", "web", "fbsim_core.d.ts"),
+  join(ROOT, "pkg", "node", "fbsim_core.d.ts"),
+];
+
+/**
+ * Recursively collect all `.rs` files under a directory.
+ */
+function collectRsFiles(dir) {
+  const results = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      results.push(...collectRsFiles(full));
+    } else if (extname(entry) === ".rs") {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+/**
+ * Parse a Rust source file and extract doc comments for Tsify-derived types.
+ *
+ * Returns a Map<string, string> where key = type name, value = JSDoc block.
+ *
+ * We look for patterns like:
+ *   /// Some doc comment
+ *   /// More doc comment
+ *   #[cfg_attr(feature = "wasm", derive(Tsify))]   // or derive(tsify_next::Tsify)
+ *   #[tsify(...)]
+ *   pub struct FooBar {
+ *
+ * Or in wasm/ files:
+ *   /// Some doc comment
+ *   #[derive(Clone, Debug, Serialize, Tsify)]
+ *   #[tsify(...)]
+ *   pub struct FooBar {
+ */
+function extractTsifyDocs(filePath) {
+  const content = readFileSync(filePath, "utf-8");
+  const lines = content.split("\n");
+  const docs = new Map();
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+
+    // Check if this line has a Tsify derive
+    const isTsifyDerive =
+      /derive\(.*Tsify.*\)/.test(line) ||
+      /derive\(.*tsify_next::Tsify.*\)/.test(line);
+
+    if (!isTsifyDerive) continue;
+
+    // Walk backwards from the derive line to collect doc comments.
+    // Skip over other #[...] attribute lines.
+    let docStart = i - 1;
+    while (docStart >= 0) {
+      const prev = lines[docStart].trim();
+      if (prev.startsWith("///")) {
+        docStart--;
+      } else if (prev.startsWith("#[")) {
+        // Another attribute above the doc comments - skip it
+        docStart--;
+      } else {
+        break;
+      }
+    }
+    docStart++; // move back to the first doc/attr line
+
+    // Collect only the `///` lines
+    const docLines = [];
+    for (let j = docStart; j < i; j++) {
+      const l = lines[j].trim();
+      if (l.startsWith("///")) {
+        // Strip the `/// ` or `///` prefix
+        const text = l.replace(/^\/\/\/\s?/, "");
+        docLines.push(text);
+      }
+    }
+
+    if (docLines.length === 0) continue;
+
+    // Walk forward from the derive line to find the type declaration
+    let typeName = null;
+    for (let j = i + 1; j < lines.length && j < i + 10; j++) {
+      const decl = lines[j].trim();
+      const match = decl.match(
+        /^pub\s+(?:struct|enum|type)\s+(\w+)/
+      );
+      if (match) {
+        typeName = match[1];
+        break;
+      }
+    }
+
+    if (!typeName) continue;
+
+    // Build JSDoc block
+    const jsdoc = [
+      "/**",
+      ...docLines.map((l) => (l ? ` * ${l}` : " *")),
+      " */",
+    ].join("\n");
+
+    docs.set(typeName, jsdoc);
+  }
+
+  return docs;
+}
+
+/**
+ * Inject JSDoc comments into a `.d.ts` file.
+ *
+ * For each type in `docs`, find the matching `export interface X`,
+ * `export type X`, or `export enum X` declaration and prepend the JSDoc.
+ */
+function injectJsdoc(dtsPath, docs) {
+  let content;
+  try {
+    content = readFileSync(dtsPath, "utf-8");
+  } catch {
+    console.warn(`  Skipping ${dtsPath} (file not found)`);
+    return 0;
+  }
+
+  let injected = 0;
+
+  for (const [typeName, jsdoc] of docs) {
+    // Match export declarations that don't already have a JSDoc comment
+    // Handles: export interface X, export type X, export enum X
+    const pattern = new RegExp(
+      `^(export\\s+(?:interface|type|enum)\\s+${typeName}\\b)`,
+      "m"
+    );
+
+    if (!pattern.test(content)) continue;
+
+    // Check if there's already a JSDoc comment before this declaration
+    const alreadyDocumented = new RegExp(
+      `\\*/\\s*\\n\\s*export\\s+(?:interface|type|enum)\\s+${typeName}\\b`
+    );
+    if (alreadyDocumented.test(content)) continue;
+
+    content = content.replace(pattern, `${jsdoc}\n$1`);
+    injected++;
+  }
+
+  if (injected > 0) {
+    writeFileSync(dtsPath, content, "utf-8");
+  }
+
+  return injected;
+}
+
+/**
+ * Fix readonly modifier mismatches between Tsify interfaces and
+ * wasm-bindgen classes.
+ *
+ * When a type has both `export interface Foo { bar: T; }` (from Tsify)
+ * and `export class Foo { readonly bar: T; }` (from wasm-bindgen),
+ * TypeScript declaration merging requires identical modifiers. This
+ * function adds `readonly` to interface fields that have a corresponding
+ * `readonly` property in the class.
+ */
+function fixReadonlyModifiers(dtsPath) {
+  let content;
+  try {
+    content = readFileSync(dtsPath, "utf-8");
+  } catch {
+    return 0;
+  }
+
+  // Find all type names that have both an interface and a class declaration
+  const interfaceNames = new Set(
+    [...content.matchAll(/^export\s+interface\s+(\w+)/gm)].map((m) => m[1])
+  );
+  const classNames = new Set(
+    [...content.matchAll(/^export\s+class\s+(\w+)/gm)].map((m) => m[1])
+  );
+  const conflicts = [...interfaceNames].filter((n) => classNames.has(n));
+
+  if (conflicts.length === 0) return 0;
+
+  let fixed = 0;
+
+  for (const name of conflicts) {
+    // Extract readonly property names from the class declaration
+    const classPattern = new RegExp(
+      `^export\\s+class\\s+${name}\\b[^}]*?^}`,
+      "ms"
+    );
+    const classMatch = content.match(classPattern);
+    if (!classMatch) continue;
+
+    const readonlyProps = new Set(
+      [...classMatch[0].matchAll(/^\s+readonly\s+(\w+)\s*:/gm)].map(
+        (m) => m[1]
+      )
+    );
+    if (readonlyProps.size === 0) continue;
+
+    // Find the interface block and add readonly to matching fields.
+    // We match the full interface block, then do field-level replacements
+    // inside it.
+    const ifacePattern = new RegExp(
+      `(^export\\s+interface\\s+${name}\\b[\\s\\S]*?^})`,
+      "m"
+    );
+    const ifaceMatch = content.match(ifacePattern);
+    if (!ifaceMatch) continue;
+
+    let ifaceBlock = ifaceMatch[0];
+    let changed = false;
+
+    for (const prop of readonlyProps) {
+      // Match a non-readonly field with this property name inside the
+      // interface (camelCase in the class may differ from snake_case in
+      // the interface, so we need to match by converting).  However the
+      // TS errors only fire when the names are identical, so we only
+      // need to fix exact-name matches.
+      const fieldPattern = new RegExp(
+        `^(\\s+)(?!readonly\\s)(${prop}\\s*[?]?\\s*:)`,
+        "m"
+      );
+      if (fieldPattern.test(ifaceBlock)) {
+        ifaceBlock = ifaceBlock.replace(fieldPattern, "$1readonly $2");
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      content = content.replace(ifaceMatch[0], ifaceBlock);
+      fixed++;
+    }
+  }
+
+  if (fixed > 0) {
+    writeFileSync(dtsPath, content, "utf-8");
+    console.log(
+      `Fixed readonly modifiers in ${fixed} interface(s) in ${dtsPath}`
+    );
+  }
+
+  return fixed;
+}
+
+// ── Main ────────────────────────────────────────────────────────────────
+
+const rsFiles = collectRsFiles(SRC_DIR);
+const allDocs = new Map();
+
+for (const file of rsFiles) {
+  const docs = extractTsifyDocs(file);
+  for (const [name, jsdoc] of docs) {
+    allDocs.set(name, jsdoc);
+  }
+}
+
+console.log(`Found ${allDocs.size} Tsify-derived types with doc comments:`);
+for (const name of allDocs.keys()) {
+  console.log(`  - ${name}`);
+}
+
+let totalInjected = 0;
+for (const dtsPath of DTS_PATHS) {
+  const count = injectJsdoc(dtsPath, allDocs);
+  if (count > 0) {
+    console.log(`Injected ${count} JSDoc comments into ${dtsPath}`);
+  }
+  totalInjected += count;
+}
+
+if (totalInjected === 0) {
+  console.log("No JSDoc comments injected (types may already be documented or .d.ts files not found).");
+}
+
+// Fix readonly modifier mismatches between Tsify interfaces and
+// wasm-bindgen classes so TypeScript declaration merging succeeds.
+for (const dtsPath of DTS_PATHS) {
+  fixReadonlyModifiers(dtsPath);
+}

--- a/src/game/context.rs
+++ b/src/game/context.rs
@@ -3,7 +3,9 @@
 use rocket_okapi::okapi::schemars;
 #[cfg(feature = "rocket_okapi")]
 use rocket_okapi::okapi::schemars::JsonSchema;
-use serde::{Serialize, Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
+#[cfg(feature = "wasm")]
+use tsify_next::Tsify;
 
 use crate::game::play::context::PlayContext;
 use crate::game::play::result::{ScoreResult, PlayResult};
@@ -244,6 +246,8 @@ pub struct GameContextUpdateOptions {
 ///
 /// A `GameContext` represents a game scenario
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[cfg_attr(feature = "wasm", derive(Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize)]
 pub struct GameContext {
     home_team_short: String,

--- a/src/game/play.rs
+++ b/src/game/play.rs
@@ -9,6 +9,8 @@ use rocket_okapi::okapi::schemars;
 use rocket_okapi::okapi::schemars::JsonSchema;
 use serde::{Serialize, Deserialize};
 use rand::Rng;
+#[cfg(feature = "wasm")]
+use tsify_next::Tsify;
 
 use crate::game::context::GameContext;
 use crate::game::play::call::{PlayCallSimulator, PlayCall};
@@ -300,6 +302,8 @@ impl PlaySimulator {
 ///
 /// Enumerates the possible outcomes of a drive
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[cfg_attr(feature = "wasm", derive(Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
 pub enum DriveResult {
     None,

--- a/src/game/play/result.rs
+++ b/src/game/play/result.rs
@@ -3,7 +3,9 @@
 use rocket_okapi::okapi::schemars;
 #[cfg(feature = "rocket_okapi")]
 use rocket_okapi::okapi::schemars::JsonSchema;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "wasm")]
+use tsify_next::Tsify;
 
 pub mod betweenplay;
 pub mod fieldgoal;
@@ -50,7 +52,10 @@ pub trait PlayResult {
 /// The `PlayTypeResult` enum is used to store the result of an arbirary play
 /// for gathering game statistics
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[cfg_attr(feature = "wasm", derive(Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data")]
 pub enum PlayTypeResult {
     BetweenPlay(BetweenPlayResult),
     Run(RunResult),
@@ -314,7 +319,9 @@ pub trait PlayResultSimulator {
 /// `ScoreResult` enum
 ///
 /// Enumerates the various ways a team can score points in football
-#[derive(PartialEq, Clone, Copy, Eq, Ord, PartialOrd, Debug, Default)]
+#[cfg_attr(feature = "wasm", derive(Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[derive(PartialEq, Clone, Copy, Eq, Ord, PartialOrd, Debug, Default, Serialize, Deserialize)]
 pub enum ScoreResult {
     #[default] None,
     ExtraPoint,

--- a/src/game/play/result/betweenplay.rs
+++ b/src/game/play/result/betweenplay.rs
@@ -4,7 +4,9 @@ use rand::Rng;
 use rocket_okapi::okapi::schemars;
 #[cfg(feature = "rocket_okapi")]
 use rocket_okapi::okapi::schemars::JsonSchema;
-use serde::{Serialize, Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
+#[cfg(feature = "wasm")]
+use tsify_next::Tsify;
 use rand_distr::{SkewNormal, Normal, Distribution};
 
 use crate::game::context::{GameContext, GameContextBuilder, GameContextUpdateOptions};
@@ -77,6 +79,8 @@ impl BetweenPlayResultRaw {
 /// A `BetweenPlayResult` represents any activity between plays, such as the
 /// clock running in-between plays & timeouts called after the play
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[cfg_attr(feature = "wasm", derive(Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize)]
 pub struct BetweenPlayResult {
     duration: u32,

--- a/src/game/play/result/fieldgoal.rs
+++ b/src/game/play/result/fieldgoal.rs
@@ -4,7 +4,9 @@ use rand::Rng;
 use rocket_okapi::okapi::schemars;
 #[cfg(feature = "rocket_okapi")]
 use rocket_okapi::okapi::schemars::JsonSchema;
-use serde::{Serialize, Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
+#[cfg(feature = "wasm")]
+use tsify_next::Tsify;
 use rand_distr::{Distribution, Exp, SkewNormal};
 
 use crate::game::context::GameContext;
@@ -124,6 +126,8 @@ impl FieldGoalResultRaw {
 ///
 /// A `FieldGoalResult` represents a result of a field goal
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[cfg_attr(feature = "wasm", derive(Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize)]
 pub struct FieldGoalResult {
     field_goal_distance: i32,

--- a/src/game/play/result/kickoff.rs
+++ b/src/game/play/result/kickoff.rs
@@ -4,7 +4,9 @@ use rand::Rng;
 use rocket_okapi::okapi::schemars;
 #[cfg(feature = "rocket_okapi")]
 use rocket_okapi::okapi::schemars::JsonSchema;
-use serde::{Serialize, Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
+#[cfg(feature = "wasm")]
+use tsify_next::Tsify;
 use rand_distr::{Normal, Distribution, Exp, SkewNormal};
 
 use crate::game::context::GameContext;
@@ -156,6 +158,8 @@ impl KickoffResultRaw {
 ///
 /// A `KickoffResult` represents a result of a kickoff
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[cfg_attr(feature = "wasm", derive(Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize)]
 pub struct KickoffResult {
     kickoff_yards: i32,

--- a/src/game/play/result/pass.rs
+++ b/src/game/play/result/pass.rs
@@ -4,7 +4,9 @@ use rand::Rng;
 use rocket_okapi::okapi::schemars;
 #[cfg(feature = "rocket_okapi")]
 use rocket_okapi::okapi::schemars::JsonSchema;
-use serde::{Serialize, Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
+#[cfg(feature = "wasm")]
+use tsify_next::Tsify;
 use rand_distr::{Normal, Distribution, Exp, SkewNormal};
 
 use crate::game::context::GameContext;
@@ -316,6 +318,8 @@ impl PassResultRaw {
 ///
 /// A `PassResult` represents a result of a pass play
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[cfg_attr(feature = "wasm", derive(Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize)]
 pub struct PassResult {
     play_duration: u32,

--- a/src/game/play/result/punt.rs
+++ b/src/game/play/result/punt.rs
@@ -4,7 +4,9 @@ use rand::Rng;
 use rocket_okapi::okapi::schemars;
 #[cfg(feature = "rocket_okapi")]
 use rocket_okapi::okapi::schemars::JsonSchema;
-use serde::{Serialize, Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
+#[cfg(feature = "wasm")]
+use tsify_next::Tsify;
 use rand_distr::{Normal, Distribution, Exp, SkewNormal};
 
 use crate::game::context::GameContext;
@@ -215,6 +217,8 @@ impl PuntResultRaw {
 ///
 /// A `PuntResult` represents a result of a punt play
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[cfg_attr(feature = "wasm", derive(Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize)]
 pub struct PuntResult {
     fumble_return_yards: i32,

--- a/src/game/play/result/run.rs
+++ b/src/game/play/result/run.rs
@@ -4,7 +4,9 @@ use rand::Rng;
 use rocket_okapi::okapi::schemars;
 #[cfg(feature = "rocket_okapi")]
 use rocket_okapi::okapi::schemars::JsonSchema;
-use serde::{Serialize, Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
+#[cfg(feature = "wasm")]
+use tsify_next::Tsify;
 use rand_distr::{Normal, Distribution, Exp};
 
 use crate::game::context::GameContext;
@@ -131,6 +133,8 @@ impl RunResultRaw {
 ///
 /// A `RunResult` represents a result of a run play
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[cfg_attr(feature = "wasm", derive(Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize)]
 pub struct RunResult {
     yards_gained: i32,

--- a/src/game/stat.rs
+++ b/src/game/stat.rs
@@ -3,12 +3,16 @@
 use rocket_okapi::okapi::schemars;
 #[cfg(feature = "rocket_okapi")]
 use rocket_okapi::okapi::schemars::JsonSchema;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "wasm")]
+use tsify_next::Tsify;
 
 /// # `RushingStats` struct
 ///
 /// A `RushingStats` represents aggregated rushing statistics
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[cfg_attr(feature = "wasm", derive(Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Default, Serialize, Deserialize)]
 pub struct RushingStats {
     rushes: u32,
@@ -181,6 +185,8 @@ impl std::fmt::Display for RushingStats {
 ///
 /// A `PassingStats` represents aggregated passing statistics
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[cfg_attr(feature = "wasm", derive(Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Default, Serialize, Deserialize)]
 pub struct PassingStats {
     attempts: u32,
@@ -383,6 +389,8 @@ impl std::fmt::Display for PassingStats {
 ///
 /// A `ReceivingStats` represents aggregated receiving statistics
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[cfg_attr(feature = "wasm", derive(Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Default, Serialize, Deserialize)]
 pub struct ReceivingStats {
     targets: u32,
@@ -581,10 +589,12 @@ impl std::fmt::Display for ReceivingStats {
     }
 }
 
-/// # `ReceivingStats` struct
+/// # `OffensiveStats` struct
 ///
-/// A `ReceivingStats` represents aggregated receiving statistics
+/// An `OffensiveStats` represents aggregated offensive statistics
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[cfg_attr(feature = "wasm", derive(Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Default, Serialize, Deserialize)]
 pub struct OffensiveStats {
     passing: PassingStats,

--- a/src/league/matchup.rs
+++ b/src/league/matchup.rs
@@ -16,6 +16,8 @@ use crate::league::season::matchup::LeagueSeasonMatchups;
 /// A 3-tuple of usizes representing the number of wins, losses, and ties
 /// for a given team.  May be for a season or for many seasons.
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[cfg_attr(feature = "wasm", derive(tsify_next::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize, Deserialize)]
 pub struct LeagueTeamRecord {
     wins: usize,
@@ -156,7 +158,7 @@ impl fmt::Display for LeagueTeamRecord {
 /// # `LeagueMatchups` struct
 ///
 /// Represents a list of matchups for a given team during a given season
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize)]
 pub struct LeagueMatchups {
     matchups: BTreeMap<usize, LeagueSeasonMatchups>
 }

--- a/src/league/season.rs
+++ b/src/league/season.rs
@@ -304,6 +304,8 @@ impl LeagueSeasonRaw {
 ///
 /// A `LeagueSeasonScheduleOptions` represents a collection of options used
 /// to generate a season schedule
+#[cfg_attr(feature = "wasm", derive(tsify_next::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize, Deserialize)]
 pub struct LeagueSeasonScheduleOptions {
     pub weeks: Option<usize>,
@@ -356,6 +358,8 @@ impl LeagueSeasonScheduleOptions {
 ///
 /// Options for generating playoffs. Supports both single-bracket and
 /// multi-conference bracket modes.
+#[cfg_attr(feature = "wasm", derive(tsify_next::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize, Deserialize)]
 pub struct LeagueSeasonPlayoffOptions {
     /// Total number of playoff teams (used when not using conference brackets)

--- a/src/league/season/matchup.rs
+++ b/src/league/season/matchup.rs
@@ -16,6 +16,8 @@ use crate::league::matchup::LeagueTeamRecord;
 ///
 /// A `LeagueSeasonMatchup` represents a matchup during a week of a football season
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[cfg_attr(feature = "wasm", derive(tsify_next::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize, Deserialize)]
 pub struct LeagueSeasonMatchup {
     home_team: usize,
@@ -348,7 +350,7 @@ impl std::fmt::Display for LeagueSeasonMatchup {
 /// # `LeagueSeasonMatchups` struct
 ///
 /// Represents a list of matchups for a given team during a given season
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize)]
 pub struct LeagueSeasonMatchups {
     team_id: usize,
     matchups: Vec<Option<LeagueSeasonMatchup>>

--- a/src/league/season/playoffs.rs
+++ b/src/league/season/playoffs.rs
@@ -200,6 +200,8 @@ impl TryFrom<LeagueSeasonPlayoffsRaw> for LeagueSeasonPlayoffs {
 ///
 /// Represents a single team's playoff entry with its seed and short name.
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[cfg_attr(feature = "wasm", derive(tsify_next::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi))]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Default, Debug, Serialize)]
 pub struct PlayoffTeam {
     seed: usize,
@@ -233,6 +235,8 @@ impl PlayoffTeam {
 /// A collection of teams participating in the playoffs, organized by conference.
 /// Conference ID 0 is used for non-conference playoffs.
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[cfg_attr(feature = "wasm", derive(tsify_next::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi))]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Default, Debug, Serialize)]
 pub struct PlayoffTeams {
     /// conference_id -> team_id -> PlayoffTeam
@@ -510,6 +514,8 @@ impl<'de> Deserialize<'de> for PlayoffTeams {
 /// playoffs use bracket ID 0. Multi-conference playoffs have one bracket per
 /// conference, plus a `winners_bracket` for the championship between conference winners.
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[cfg_attr(feature = "wasm", derive(tsify_next::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi))]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Default, Debug, Serialize)]
 pub struct LeagueSeasonPlayoffs {
     /// Teams participating in the playoffs

--- a/src/league/season/playoffs/picture.rs
+++ b/src/league/season/playoffs/picture.rs
@@ -14,6 +14,8 @@ use crate::league::season::LeagueSeason;
 ///
 /// Represents a team's playoff qualification status during an ongoing season
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[cfg_attr(feature = "wasm", derive(tsify_next::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Default, Serialize, Deserialize)]
 pub enum PlayoffStatus {
     /// Team has clinched the #1 seed
@@ -32,6 +34,8 @@ pub enum PlayoffStatus {
 ///
 /// Represents a single team's entry in the playoff picture
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[cfg_attr(feature = "wasm", derive(tsify_next::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi))]
 #[derive(Clone, PartialEq, Debug, Default, Serialize, Deserialize)]
 pub struct PlayoffPictureEntry {
     team_id: usize,
@@ -237,6 +241,8 @@ impl RecordBounds {
 ///
 /// Options for configuring how the playoff picture is generated
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[cfg_attr(feature = "wasm", derive(tsify_next::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Clone, PartialEq, Debug, Default, Serialize, Deserialize)]
 pub struct PlayoffPictureOptions {
     /// If `Some(true)`, force conference-based playoff picture.
@@ -252,6 +258,8 @@ pub struct PlayoffPictureOptions {
 /// Represents the complete playoff picture for a season, showing the
 /// qualification status of all teams
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[cfg_attr(feature = "wasm", derive(tsify_next::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi))]
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub struct PlayoffPicture {
     num_playoff_teams: usize,

--- a/src/league/season/week.rs
+++ b/src/league/season/week.rs
@@ -11,6 +11,8 @@ use crate::league::season::matchup::LeagueSeasonMatchup;
 ///
 /// A `LeagueSeasonWeek` represents a week of a football season
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[cfg_attr(feature = "wasm", derive(tsify_next::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize, Deserialize)]
 pub struct LeagueSeasonWeek {
     matchups: Vec<LeagueSeasonMatchup>

--- a/src/league/team.rs
+++ b/src/league/team.rs
@@ -13,6 +13,8 @@ use rocket_okapi::okapi::schemars::JsonSchema;
 /// over the course of many seasons, this struct is mainly just used
 /// as a unique ID for a given team
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[cfg_attr(feature = "wasm", derive(tsify_next::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize, Deserialize)]
 pub struct LeagueTeam {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,6 @@
 pub mod game;
 pub mod league;
 pub mod team;
+
+#[cfg(feature = "wasm")]
+pub mod wasm;

--- a/src/team.rs
+++ b/src/team.rs
@@ -7,7 +7,9 @@ pub mod offense;
 use rocket_okapi::okapi::schemars;
 #[cfg(feature = "rocket_okapi")]
 use rocket_okapi::okapi::schemars::JsonSchema;
-use serde::{Serialize, Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
+#[cfg(feature = "wasm")]
+use tsify_next::Tsify;
 
 use crate::game::play::PlaySimulatable;
 use crate::game::score::ScoreSimulatable;
@@ -61,6 +63,8 @@ impl FootballTeamRaw {
 ///
 /// A `FootballTeam` represents a football team
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[cfg_attr(feature = "wasm", derive(Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Default, Serialize)]
 pub struct FootballTeam {
     name: String,

--- a/src/team/coach.rs
+++ b/src/team/coach.rs
@@ -3,7 +3,9 @@
 use rocket_okapi::okapi::schemars;
 #[cfg(feature = "rocket_okapi")]
 use rocket_okapi::okapi::schemars::JsonSchema;
-use serde::{Serialize, Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
+#[cfg(feature = "wasm")]
+use tsify_next::Tsify;
 
 /// # `FootballTeamCoachRaw` struct
 ///
@@ -52,6 +54,8 @@ impl FootballTeamCoachRaw {
 ///
 /// A `FootballTeamCoach` represents a football team coach
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[cfg_attr(feature = "wasm", derive(Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize)]
 pub struct FootballTeamCoach {
     risk_taking: u32,

--- a/src/team/defense.rs
+++ b/src/team/defense.rs
@@ -3,7 +3,9 @@
 use rocket_okapi::okapi::schemars;
 #[cfg(feature = "rocket_okapi")]
 use rocket_okapi::okapi::schemars::JsonSchema;
-use serde::{Serialize, Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
+#[cfg(feature = "wasm")]
+use tsify_next::Tsify;
 
 const DEFENSE_ADVANTAGE: u32 = 3_u32;
 
@@ -81,6 +83,8 @@ impl FootballTeamDefenseRaw {
 ///
 /// A `FootballTeamDefense` represents a football team defense
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[cfg_attr(feature = "wasm", derive(Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize)]
 pub struct FootballTeamDefense {
     blitzing: u32,

--- a/src/team/offense.rs
+++ b/src/team/offense.rs
@@ -3,7 +3,9 @@
 use rocket_okapi::okapi::schemars;
 #[cfg(feature = "rocket_okapi")]
 use rocket_okapi::okapi::schemars::JsonSchema;
-use serde::{Serialize, Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
+#[cfg(feature = "wasm")]
+use tsify_next::Tsify;
 
 const OFFENSE_ADVANTAGE: u32 = 3_u32;
 
@@ -117,6 +119,8 @@ impl FootballTeamOffenseRaw {
 ///
 /// A `FootballTeamOffense` represents a football team offense
 #[cfg_attr(feature = "rocket_okapi", derive(JsonSchema))]
+#[cfg_attr(feature = "wasm", derive(Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Serialize)]
 pub struct FootballTeamOffense {
     passing: u32,

--- a/src/wasm/conference.rs
+++ b/src/wasm/conference.rs
@@ -1,0 +1,213 @@
+//! WASM bridge types for league conference and division management.
+//!
+//! These types provide JavaScript/TypeScript-compatible wrappers around the
+//! core fbsim-core Rust types. They are intended exclusively for JS/TS
+//! consumers via WebAssembly and are not part of the public Rust API.
+//!
+//! Feature-gated behind the `wasm` Cargo feature. Compiled to WebAssembly
+//! via `wasm-pack`.
+
+use wasm_bindgen::prelude::*;
+
+use crate::league::season::conference::{LeagueConference, LeagueDivision};
+
+/// A WASM-friendly wrapper around `LeagueDivision`.
+#[wasm_bindgen(js_name = "LeagueDivision")]
+pub struct WasmLeagueDivision {
+    inner: LeagueDivision,
+}
+
+#[wasm_bindgen(js_class = "LeagueDivision")]
+impl WasmLeagueDivision {
+    /// Creates a new empty division.
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> WasmLeagueDivision {
+        WasmLeagueDivision {
+            inner: LeagueDivision::new(),
+        }
+    }
+
+    /// Creates a new division with the given name.
+    #[wasm_bindgen(js_name = "withName")]
+    pub fn with_name(name: &str) -> WasmLeagueDivision {
+        WasmLeagueDivision {
+            inner: LeagueDivision::with_name(name),
+        }
+    }
+
+    /// Gets the division name.
+    #[wasm_bindgen(getter)]
+    pub fn name(&self) -> String {
+        self.inner.name().to_string()
+    }
+
+    /// Sets the division name.
+    #[wasm_bindgen(setter)]
+    pub fn set_name(&mut self, name: &str) {
+        *self.inner.name_mut() = name.to_string();
+    }
+
+    /// Adds a team to the division by ID.
+    #[wasm_bindgen(js_name = "addTeam")]
+    pub fn add_team(&mut self, team_id: usize) -> Result<(), JsError> {
+        self.inner
+            .add_team(team_id)
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Returns the team IDs in this division.
+    #[wasm_bindgen(getter)]
+    pub fn teams(&self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(self.inner.teams())
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Checks if a team is in this division.
+    #[wasm_bindgen(js_name = "containsTeam")]
+    pub fn contains_team(&self, team_id: usize) -> bool {
+        self.inner.contains_team(team_id)
+    }
+
+    /// Returns the number of teams in this division.
+    #[wasm_bindgen(getter, js_name = "numTeams")]
+    pub fn num_teams(&self) -> usize {
+        self.inner.num_teams()
+    }
+
+    /// Returns the division as a JSON-serializable object.
+    #[wasm_bindgen(js_name = "toJSON")]
+    pub fn to_json(&self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(&self.inner)
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+}
+
+impl Default for WasmLeagueDivision {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WasmLeagueDivision {
+    /// Returns a reference to the inner `LeagueDivision`.
+    pub fn inner(&self) -> &LeagueDivision {
+        &self.inner
+    }
+
+    /// Consumes the wrapper, returning the inner `LeagueDivision`.
+    pub fn into_inner(self) -> LeagueDivision {
+        self.inner
+    }
+
+    /// Creates a wrapper from an existing `LeagueDivision`.
+    pub fn from_inner(inner: LeagueDivision) -> Self {
+        WasmLeagueDivision { inner }
+    }
+}
+
+/// A WASM-friendly wrapper around `LeagueConference`.
+#[wasm_bindgen(js_name = "LeagueConference")]
+pub struct WasmLeagueConference {
+    inner: LeagueConference,
+}
+
+#[wasm_bindgen(js_class = "LeagueConference")]
+impl WasmLeagueConference {
+    /// Creates a new empty conference.
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> WasmLeagueConference {
+        WasmLeagueConference {
+            inner: LeagueConference::new(),
+        }
+    }
+
+    /// Creates a new conference with the given name.
+    #[wasm_bindgen(js_name = "withName")]
+    pub fn with_name(name: &str) -> WasmLeagueConference {
+        WasmLeagueConference {
+            inner: LeagueConference::with_name(name),
+        }
+    }
+
+    /// Gets the conference name.
+    #[wasm_bindgen(getter)]
+    pub fn name(&self) -> String {
+        self.inner.name().to_string()
+    }
+
+    /// Sets the conference name.
+    #[wasm_bindgen(setter)]
+    pub fn set_name(&mut self, name: &str) {
+        *self.inner.name_mut() = name.to_string();
+    }
+
+    /// Adds a division to the conference (takes ownership of the division).
+    #[wasm_bindgen(js_name = "addDivision")]
+    pub fn add_division(&mut self, division: WasmLeagueDivision) -> Result<(), JsError> {
+        self.inner
+            .add_division(division.into_inner())
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Returns the divisions as a JSON array.
+    #[wasm_bindgen(getter)]
+    pub fn divisions(&self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(self.inner.divisions())
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Returns all team IDs across all divisions.
+    #[wasm_bindgen(js_name = "allTeams")]
+    pub fn all_teams(&self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(&self.inner.all_teams())
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Checks if a team is in this conference.
+    #[wasm_bindgen(js_name = "containsTeam")]
+    pub fn contains_team(&self, team_id: usize) -> bool {
+        self.inner.contains_team(team_id)
+    }
+
+    /// Returns the number of divisions in this conference.
+    #[wasm_bindgen(getter, js_name = "numDivisions")]
+    pub fn num_divisions(&self) -> usize {
+        self.inner.num_divisions()
+    }
+
+    /// Returns the total number of teams in this conference.
+    #[wasm_bindgen(getter, js_name = "numTeams")]
+    pub fn num_teams(&self) -> usize {
+        self.inner.num_teams()
+    }
+
+    /// Returns the conference as a JSON-serializable object.
+    #[wasm_bindgen(js_name = "toJSON")]
+    pub fn to_json(&self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(&self.inner)
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+}
+
+impl Default for WasmLeagueConference {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WasmLeagueConference {
+    /// Returns a reference to the inner `LeagueConference`.
+    pub fn inner(&self) -> &LeagueConference {
+        &self.inner
+    }
+
+    /// Consumes the wrapper, returning the inner `LeagueConference`.
+    pub fn into_inner(self) -> LeagueConference {
+        self.inner
+    }
+
+    /// Creates a wrapper from an existing `LeagueConference`.
+    pub fn from_inner(inner: LeagueConference) -> Self {
+        WasmLeagueConference { inner }
+    }
+}

--- a/src/wasm/game.rs
+++ b/src/wasm/game.rs
@@ -1,0 +1,246 @@
+//! WASM bridge types for game simulation.
+//!
+//! These types provide JavaScript/TypeScript-compatible wrappers around the
+//! core fbsim-core Rust types. They are intended exclusively for JS/TS
+//! consumers via WebAssembly and are not part of the public Rust API.
+//!
+//! Feature-gated behind the `wasm` Cargo feature. Compiled to WebAssembly
+//! via `wasm-pack`.
+
+use wasm_bindgen::prelude::*;
+
+use crate::game::context::GameContext;
+use crate::game::play::{Game as CoreGame, GameSimulator};
+use crate::wasm::play::{Drive, Play};
+use crate::wasm::rng::WasmRng;
+use crate::wasm::team::WasmFootballTeam;
+
+/// A WASM-friendly wrapper around the core `Game` type.
+///
+/// This class holds the accumulated game log (drives and plays) and
+/// provides query methods for accessing enriched play data, stats,
+/// and serialization.
+#[wasm_bindgen(js_name = "Game")]
+pub struct WasmGame {
+    inner: CoreGame,
+}
+
+#[wasm_bindgen(js_class = "Game")]
+impl WasmGame {
+    /// Creates a new empty game.
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> WasmGame {
+        WasmGame {
+            inner: CoreGame::new(),
+        }
+    }
+
+    /// Returns true if the game is complete.
+    #[wasm_bindgen(getter)]
+    pub fn complete(&self) -> bool {
+        self.inner.complete()
+    }
+
+    /// Returns the number of drives in the game so far.
+    #[wasm_bindgen(getter, js_name = "driveCount")]
+    pub fn drive_count(&self) -> usize {
+        self.inner.drives().len()
+    }
+
+    /// Returns the total number of plays in the game so far.
+    #[wasm_bindgen(getter, js_name = "playCount")]
+    pub fn play_count(&self) -> usize {
+        self.inner.drives().iter().map(|d| d.plays().len()).sum()
+    }
+
+    /// Returns a specific drive by index with enriched play data.
+    ///
+    /// # Arguments
+    /// * `index` - The drive index (0-based)
+    #[wasm_bindgen(js_name = "getDrive")]
+    pub fn get_drive(&self, index: usize) -> Result<Drive, JsError> {
+        self.inner
+            .drives()
+            .get(index)
+            .map(Drive::from)
+            .ok_or_else(|| JsError::new(&format!("Drive {} not found", index)))
+    }
+
+    /// Returns the latest play with enriched data, or null if no plays
+    /// have been simulated.
+    #[wasm_bindgen(js_name = "getLatestPlay")]
+    pub fn get_latest_play(&self) -> Option<Play> {
+        self.inner
+            .drives()
+            .last()
+            .and_then(|d| d.plays().last())
+            .map(Play::from)
+    }
+
+    /// Returns the home team's offensive stats as a JSON object.
+    #[wasm_bindgen(js_name = "homeStats")]
+    pub fn home_stats(&self) -> Result<JsValue, JsError> {
+        let stats = self.inner.home_stats();
+        serde_wasm_bindgen::to_value(&stats).map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Returns the away team's offensive stats as a JSON object.
+    #[wasm_bindgen(js_name = "awayStats")]
+    pub fn away_stats(&self) -> Result<JsValue, JsError> {
+        let stats = self.inner.away_stats();
+        serde_wasm_bindgen::to_value(&stats).map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Returns the game as a JSON-serializable object.
+    ///
+    /// The structure matches the core `Game` type used in league matchups.
+    #[wasm_bindgen(js_name = "toJSON")]
+    pub fn to_json(&self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(&self.inner).map_err(|e| JsError::new(&e.to_string()))
+    }
+}
+
+impl Default for WasmGame {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WasmGame {
+    /// Returns a reference to the inner `Game`.
+    pub fn inner(&self) -> &CoreGame {
+        &self.inner
+    }
+
+    /// Returns a mutable reference to the inner `Game`.
+    pub fn inner_mut(&mut self) -> &mut CoreGame {
+        &mut self.inner
+    }
+}
+
+/// A WASM-friendly wrapper around the core `GameSimulator` type.
+///
+/// Provides methods to simulate plays, drives, or full games.
+/// Mirrors the Rust `GameSimulator` API, accepting teams, context,
+/// and a mutable game reference as parameters.
+#[wasm_bindgen(js_name = "GameSimulator")]
+pub struct WasmGameSimulator {
+    inner: GameSimulator,
+}
+
+#[wasm_bindgen(js_class = "GameSimulator")]
+impl WasmGameSimulator {
+    /// Creates a new game simulator.
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> WasmGameSimulator {
+        WasmGameSimulator {
+            inner: GameSimulator::new(),
+        }
+    }
+
+    /// Simulates the next play.
+    ///
+    /// Mutates the `game` in place and returns the updated `GameContext`.
+    /// Call `game.getLatestPlay()` to inspect the play that was simulated.
+    ///
+    /// # Arguments
+    /// * `home` - The home team
+    /// * `away` - The away team
+    /// * `context` - The current game context
+    /// * `game` - The game log (mutated in place)
+    /// * `rng` - The random number generator
+    #[wasm_bindgen(js_name = "simPlay")]
+    pub fn sim_play(
+        &self,
+        home: &WasmFootballTeam,
+        away: &WasmFootballTeam,
+        context: GameContext,
+        game: &mut WasmGame,
+        rng: &mut WasmRng,
+    ) -> Result<GameContext, JsError> {
+        self.inner
+            .sim_play(
+                home.inner(),
+                away.inner(),
+                context,
+                &mut game.inner,
+                rng.inner_mut(),
+            )
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Simulates until the current drive is complete.
+    ///
+    /// Mutates the `game` in place and returns the updated `GameContext`.
+    ///
+    /// # Arguments
+    /// * `home` - The home team
+    /// * `away` - The away team
+    /// * `context` - The current game context
+    /// * `game` - The game log (mutated in place)
+    /// * `rng` - The random number generator
+    #[wasm_bindgen(js_name = "simDrive")]
+    pub fn sim_drive(
+        &self,
+        home: &WasmFootballTeam,
+        away: &WasmFootballTeam,
+        context: GameContext,
+        game: &mut WasmGame,
+        rng: &mut WasmRng,
+    ) -> Result<GameContext, JsError> {
+        self.inner
+            .sim_drive(
+                home.inner(),
+                away.inner(),
+                context,
+                &mut game.inner,
+                rng.inner_mut(),
+            )
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Simulates the rest of the game.
+    ///
+    /// Mutates the `game` in place and returns the updated `GameContext`.
+    ///
+    /// # Arguments
+    /// * `home` - The home team
+    /// * `away` - The away team
+    /// * `context` - The current game context
+    /// * `game` - The game log (mutated in place)
+    /// * `rng` - The random number generator
+    #[wasm_bindgen(js_name = "simGame")]
+    pub fn sim_game(
+        &self,
+        home: &WasmFootballTeam,
+        away: &WasmFootballTeam,
+        context: GameContext,
+        game: &mut WasmGame,
+        rng: &mut WasmRng,
+    ) -> Result<GameContext, JsError> {
+        self.inner
+            .sim_game(
+                home.inner(),
+                away.inner(),
+                context,
+                &mut game.inner,
+                rng.inner_mut(),
+            )
+            .map_err(|e| JsError::new(&e))
+    }
+}
+
+impl Default for WasmGameSimulator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Creates a new default `GameContext`.
+///
+/// This is a convenience function for JS/TS consumers. The returned
+/// context represents the start of a game (kickoff, Q1, 15:00).
+#[wasm_bindgen(js_name = "createGameContext")]
+pub fn create_game_context() -> GameContext {
+    GameContext::new()
+}

--- a/src/wasm/league.rs
+++ b/src/wasm/league.rs
@@ -1,0 +1,323 @@
+//! WASM bridge types for top-level league management.
+//!
+//! These types provide JavaScript/TypeScript-compatible wrappers around the
+//! core fbsim-core Rust types. They are intended exclusively for JS/TS
+//! consumers via WebAssembly and are not part of the public Rust API.
+//!
+//! Feature-gated behind the `wasm` Cargo feature. Compiled to WebAssembly
+//! via `wasm-pack`.
+
+use wasm_bindgen::prelude::*;
+
+use crate::league::season::LeagueSeasonScheduleOptions;
+use crate::league::League;
+use crate::wasm::conference::WasmLeagueConference;
+use crate::wasm::rng::WasmRng;
+use crate::wasm::team::WasmFootballTeam;
+
+/// A WASM-friendly wrapper around `League`.
+#[wasm_bindgen(js_name = "League")]
+pub struct WasmLeague {
+    inner: League,
+}
+
+#[wasm_bindgen(js_class = "League")]
+impl WasmLeague {
+    // ---------------------------------------------------------------
+    // Construction & Serialization
+    // ---------------------------------------------------------------
+
+    /// Creates a new empty league.
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> WasmLeague {
+        WasmLeague {
+            inner: League::new(),
+        }
+    }
+
+    /// Serializes the league to a JSON-compatible JS value.
+    #[wasm_bindgen(js_name = "toJSON")]
+    pub fn to_json(&self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(&self.inner)
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Deserializes a league from a JSON-compatible JS value.
+    #[wasm_bindgen(js_name = "fromJSON")]
+    pub fn from_json(value: JsValue) -> Result<WasmLeague, JsError> {
+        let inner: League =
+            serde_wasm_bindgen::from_value(value).map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(WasmLeague { inner })
+    }
+
+    // ---------------------------------------------------------------
+    // Team Management
+    // ---------------------------------------------------------------
+
+    /// Adds a new team to the league (auto-assigns an ID).
+    #[wasm_bindgen(js_name = "addTeam")]
+    pub fn add_team(&mut self) {
+        self.inner.add_team();
+    }
+
+    /// Returns the league teams as a JSON object (BTreeMap<usize, LeagueTeam>).
+    #[wasm_bindgen(getter)]
+    pub fn teams(&self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(self.inner.teams())
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Returns a specific team as a JSON object, or `undefined` if not found.
+    #[wasm_bindgen(js_name = "getTeam")]
+    pub fn get_team(&self, id: usize) -> Result<JsValue, JsError> {
+        match self.inner.team(id) {
+            Some(team) => serde_wasm_bindgen::to_value(team)
+                .map_err(|e| JsError::new(&e.to_string())),
+            None => Ok(JsValue::UNDEFINED),
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Season Management
+    // ---------------------------------------------------------------
+
+    /// Creates a new season (archives the current one if complete).
+    #[wasm_bindgen(js_name = "addSeason")]
+    pub fn add_season(&mut self) -> Result<(), JsError> {
+        self.inner.add_season().map_err(|e| JsError::new(&e))
+    }
+
+    /// Returns the current season as a JSON object, or `undefined` if none.
+    #[wasm_bindgen(getter, js_name = "currentSeason")]
+    pub fn current_season(&self) -> Result<JsValue, JsError> {
+        match self.inner.current_season() {
+            Some(season) => serde_wasm_bindgen::to_value(season)
+                .map_err(|e| JsError::new(&e.to_string())),
+            None => Ok(JsValue::UNDEFINED),
+        }
+    }
+
+    /// Returns the past seasons as a JSON array.
+    #[wasm_bindgen(getter)]
+    pub fn seasons(&self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(self.inner.seasons())
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Returns a specific season by year as JSON, or `undefined` if not found.
+    #[wasm_bindgen(js_name = "getSeason")]
+    pub fn get_season(&self, year: usize) -> Result<JsValue, JsError> {
+        match self.inner.season(year) {
+            Some(season) => serde_wasm_bindgen::to_value(season)
+                .map_err(|e| JsError::new(&e.to_string())),
+            None => Ok(JsValue::UNDEFINED),
+        }
+    }
+
+    /// Returns a specific week as JSON, or `undefined` if not found.
+    #[wasm_bindgen(js_name = "getWeek")]
+    pub fn get_week(&self, year: usize, week: usize) -> Result<JsValue, JsError> {
+        match self.inner.week(year, week) {
+            Some(w) => serde_wasm_bindgen::to_value(w)
+                .map_err(|e| JsError::new(&e.to_string())),
+            None => Ok(JsValue::UNDEFINED),
+        }
+    }
+
+    /// Returns a specific matchup as JSON, or `undefined` if not found.
+    #[wasm_bindgen(js_name = "getMatchup")]
+    pub fn get_matchup(
+        &self,
+        year: usize,
+        week: usize,
+        matchup: usize,
+    ) -> Result<JsValue, JsError> {
+        match self.inner.matchup(year, week, matchup) {
+            Some(m) => serde_wasm_bindgen::to_value(m)
+                .map_err(|e| JsError::new(&e.to_string())),
+            None => Ok(JsValue::UNDEFINED),
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Season Team & Conference Management
+    // ---------------------------------------------------------------
+
+    /// Adds a team roster to the current season.
+    #[wasm_bindgen(js_name = "addSeasonTeam")]
+    pub fn add_season_team(
+        &mut self,
+        id: usize,
+        team: &WasmFootballTeam,
+    ) -> Result<(), JsError> {
+        self.inner
+            .add_season_team(id, team.inner().clone())
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Adds a conference to the current season (takes ownership).
+    #[wasm_bindgen(js_name = "addConference")]
+    pub fn add_conference(
+        &mut self,
+        conference: WasmLeagueConference,
+    ) -> Result<(), JsError> {
+        let season = self
+            .inner
+            .current_season_mut()
+            .as_mut()
+            .ok_or_else(|| JsError::new("No current season"))?;
+        season
+            .add_conference(conference.into_inner())
+            .map_err(|e| JsError::new(&e))
+    }
+
+    // ---------------------------------------------------------------
+    // Schedule & Simulation
+    // ---------------------------------------------------------------
+
+    /// Generates the schedule for the current season.
+    #[wasm_bindgen(js_name = "generateSchedule")]
+    pub fn generate_schedule(
+        &mut self,
+        options: LeagueSeasonScheduleOptions,
+        rng: &mut WasmRng,
+    ) -> Result<(), JsError> {
+        self.inner
+            .generate_schedule(options, rng.inner_mut())
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Simulates the entire current season.
+    #[wasm_bindgen(js_name = "sim")]
+    pub fn sim(&mut self, rng: &mut WasmRng) -> Result<(), JsError> {
+        self.inner
+            .sim(rng.inner_mut())
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Simulates a single week of the current season.
+    #[wasm_bindgen(js_name = "simWeek")]
+    pub fn sim_week(&mut self, week: usize, rng: &mut WasmRng) -> Result<(), JsError> {
+        self.inner
+            .sim_week(week, rng.inner_mut())
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Simulates a single matchup of the current season. Returns game log as JSON.
+    #[wasm_bindgen(js_name = "simMatchup")]
+    pub fn sim_matchup(
+        &mut self,
+        week: usize,
+        matchup: usize,
+        rng: &mut WasmRng,
+    ) -> Result<JsValue, JsError> {
+        let game = self
+            .inner
+            .sim_matchup(week, matchup, rng.inner_mut())
+            .map_err(|e| JsError::new(&e))?;
+        serde_wasm_bindgen::to_value(&game).map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Simulates a single play of a matchup. Returns game log as JSON if the
+    /// game finished on this play, or `undefined` if still in progress.
+    #[wasm_bindgen(js_name = "simPlay")]
+    pub fn sim_play(
+        &mut self,
+        week: usize,
+        matchup: usize,
+        rng: &mut WasmRng,
+    ) -> Result<JsValue, JsError> {
+        let result = self
+            .inner
+            .sim_play(week, matchup, rng.inner_mut())
+            .map_err(|e| JsError::new(&e))?;
+        match result {
+            Some(game) => {
+                serde_wasm_bindgen::to_value(&game).map_err(|e| JsError::new(&e.to_string()))
+            }
+            None => Ok(JsValue::UNDEFINED),
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Cross-Season Queries
+    // ---------------------------------------------------------------
+
+    /// Returns all matchups for a team across all seasons as JSON.
+    #[wasm_bindgen(js_name = "teamMatchups")]
+    pub fn team_matchups(&self, id: usize) -> Result<JsValue, JsError> {
+        let matchups = self
+            .inner
+            .team_matchups(id)
+            .map_err(|e| JsError::new(&e))?;
+        serde_wasm_bindgen::to_value(&matchups).map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Returns all matchups for a team in a specific season as JSON.
+    #[wasm_bindgen(js_name = "teamSeasonMatchups")]
+    pub fn team_season_matchups(
+        &self,
+        id: usize,
+        year: usize,
+    ) -> Result<JsValue, JsError> {
+        let matchups = self
+            .inner
+            .team_season_matchups(id, year)
+            .map_err(|e| JsError::new(&e))?;
+        serde_wasm_bindgen::to_value(&matchups).map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Returns a team's all-time playoff record as JSON.
+    #[wasm_bindgen(js_name = "teamPlayoffRecord")]
+    pub fn team_playoff_record(&self, id: usize) -> Result<JsValue, JsError> {
+        let record = self
+            .inner
+            .team_playoff_record(id)
+            .map_err(|e| JsError::new(&e))?;
+        serde_wasm_bindgen::to_value(&record).map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Returns a team's total championship appearances.
+    #[wasm_bindgen(js_name = "teamChampionshipAppearances")]
+    pub fn team_championship_appearances(&self, id: usize) -> Result<usize, JsError> {
+        self.inner
+            .team_championship_appearances(id)
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Returns a team's total championship wins.
+    #[wasm_bindgen(js_name = "teamChampionshipWins")]
+    pub fn team_championship_wins(&self, id: usize) -> Result<usize, JsError> {
+        self.inner
+            .team_championship_wins(id)
+            .map_err(|e| JsError::new(&e))
+    }
+}
+
+impl Default for WasmLeague {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WasmLeague {
+    /// Returns a reference to the inner `League`.
+    pub fn inner(&self) -> &League {
+        &self.inner
+    }
+
+    /// Returns a mutable reference to the inner `League`.
+    pub fn inner_mut(&mut self) -> &mut League {
+        &mut self.inner
+    }
+
+    /// Consumes the wrapper, returning the inner `League`.
+    pub fn into_inner(self) -> League {
+        self.inner
+    }
+
+    /// Creates a wrapper from an existing `League`.
+    pub fn from_inner(inner: League) -> Self {
+        WasmLeague { inner }
+    }
+}

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -1,0 +1,39 @@
+//! WASM bridge types for fbsim-core.
+//!
+//! These types provide JavaScript/TypeScript-compatible wrappers around the
+//! core fbsim-core Rust types. They are intended exclusively for JS/TS
+//! consumers via WebAssembly and are not part of the public Rust API.
+//!
+//! Feature-gated behind the `wasm` Cargo feature. Compiled to WebAssembly
+//! via `wasm-pack`.
+
+mod conference;
+mod game;
+mod league;
+mod play;
+mod rng;
+mod season;
+mod team;
+
+pub use conference::*;
+pub use game::*;
+pub use league::*;
+pub use play::*;
+pub use rng::*;
+pub use season::*;
+pub use team::*;
+
+use wasm_bindgen::prelude::*;
+
+/// Initialize the WASM module with better error handling.
+/// This is called automatically when the module is loaded.
+#[wasm_bindgen(start)]
+pub fn init() {
+    console_error_panic_hook::set_once();
+}
+
+/// Returns the library version.
+#[wasm_bindgen(js_name = "getVersion")]
+pub fn get_version() -> String {
+    env!("CARGO_PKG_VERSION").to_string()
+}

--- a/src/wasm/play.rs
+++ b/src/wasm/play.rs
@@ -1,0 +1,119 @@
+//! WASM bridge types for enriched play and drive results.
+//!
+//! These types provide JavaScript/TypeScript-compatible wrappers around the
+//! core fbsim-core Rust types. They are intended exclusively for JS/TS
+//! consumers via WebAssembly and are not part of the public Rust API.
+//!
+//! Feature-gated behind the `wasm` Cargo feature. Compiled to WebAssembly
+//! via `wasm-pack`.
+
+use serde::Serialize;
+use tsify_next::Tsify;
+
+use crate::game::context::GameContext;
+use crate::game::play::result::{PlayResult, PlayTypeResult, ScoreResult};
+use crate::game::play::DriveResult;
+use crate::game::play::Drive as CoreDrive;
+use crate::game::play::Play as CorePlay;
+
+/// Computed values from the `PlayResult` trait.
+///
+/// This captures all the trait method outputs so JavaScript consumers
+/// don't need to reimplement the Rust logic.
+#[derive(Clone, Debug, Serialize, Tsify)]
+#[tsify(into_wasm_abi)]
+pub struct PlayResultComputed {
+    pub net_yards: i32,
+    pub play_duration: u32,
+    pub turnover: bool,
+    pub offense_score: ScoreResult,
+    pub defense_score: ScoreResult,
+    pub offense_timeout: bool,
+    pub defense_timeout: bool,
+    pub incomplete: bool,
+    pub out_of_bounds: bool,
+    pub touchback: bool,
+    pub kickoff: bool,
+    pub punt: bool,
+    pub next_play_kickoff: bool,
+    pub next_play_extra_point: bool,
+}
+
+impl From<&PlayTypeResult> for PlayResultComputed {
+    fn from(result: &PlayTypeResult) -> Self {
+        PlayResultComputed {
+            net_yards: result.net_yards(),
+            play_duration: result.play_duration(),
+            turnover: result.turnover(),
+            offense_score: result.offense_score(),
+            defense_score: result.defense_score(),
+            offense_timeout: result.offense_timeout(),
+            defense_timeout: result.defense_timeout(),
+            incomplete: result.incomplete(),
+            out_of_bounds: result.out_of_bounds(),
+            touchback: result.touchback(),
+            kickoff: result.kickoff(),
+            punt: result.punt(),
+            next_play_kickoff: result.next_play_kickoff(),
+            next_play_extra_point: result.next_play_extra_point(),
+        }
+    }
+}
+
+/// An enriched play with computed values and display strings.
+///
+/// Includes the original play data plus:
+/// - `result_computed` / `post_play_computed`: all `PlayResult` trait outputs
+/// - `description`: the play's `Display` output (e.g. "Rush 5 yards. TOUCHDOWN!")
+/// - `context_description`: the context's `Display` output (e.g. "Q1 14:22 1st & 10 ...")
+#[derive(Clone, Debug, Serialize, Tsify)]
+#[tsify(into_wasm_abi)]
+pub struct Play {
+    pub context: GameContext,
+    pub result: PlayTypeResult,
+    pub result_computed: PlayResultComputed,
+    pub post_play: PlayTypeResult,
+    pub post_play_computed: PlayResultComputed,
+    pub description: String,
+    pub context_description: String,
+}
+
+impl From<&CorePlay> for Play {
+    fn from(play: &CorePlay) -> Self {
+        Play {
+            context: play.context().clone(),
+            result: *play.result(),
+            result_computed: PlayResultComputed::from(play.result()),
+            post_play: *play.post_play(),
+            post_play_computed: PlayResultComputed::from(play.post_play()),
+            description: format!("{}", play),
+            context_description: format!("{}", play.context()),
+        }
+    }
+}
+
+/// An enriched drive with computed values and display strings.
+///
+/// Includes enriched `Play` entries, total yards, and the drive's display output.
+#[derive(Clone, Debug, Serialize, Tsify)]
+#[tsify(into_wasm_abi)]
+pub struct Drive {
+    pub plays: Vec<Play>,
+    pub result: DriveResult,
+    pub complete: bool,
+    pub total_yards: i32,
+    pub display: String,
+}
+
+impl From<&CoreDrive> for Drive {
+    fn from(drive: &CoreDrive) -> Self {
+        Drive {
+            plays: drive.plays().iter().map(Play::from).collect(),
+            result: *drive.result(),
+            complete: drive.complete(),
+            total_yards: drive.total_yards(),
+            display: format!("{}", drive),
+        }
+    }
+}
+

--- a/src/wasm/rng.rs
+++ b/src/wasm/rng.rs
@@ -1,0 +1,82 @@
+//! WASM bridge types for random number generation.
+//!
+//! These types provide JavaScript/TypeScript-compatible wrappers around the
+//! core fbsim-core Rust types. They are intended exclusively for JS/TS
+//! consumers via WebAssembly and are not part of the public Rust API.
+//!
+//! Feature-gated behind the `wasm` Cargo feature. Compiled to WebAssembly
+//! via `wasm-pack`.
+
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
+use wasm_bindgen::prelude::*;
+
+/// A WASM-compatible random number generator.
+///
+/// This wrapper uses `SmallRng` internally, which is suitable for
+/// game simulations where cryptographic security is not required.
+#[wasm_bindgen(js_name = "Rng")]
+pub struct WasmRng {
+    inner: SmallRng,
+}
+
+#[wasm_bindgen(js_class = "Rng")]
+impl WasmRng {
+    /// Creates a new RNG with a random seed.
+    ///
+    /// Entropy is obtained from the JavaScript runtime via `crypto.getRandomValues()`.
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> WasmRng {
+        WasmRng {
+            inner: SmallRng::from_entropy(),
+        }
+    }
+
+    /// Creates a new RNG with a specific seed for reproducible simulations.
+    ///
+    /// Use this when you need deterministic results, such as for testing
+    /// or replay functionality.
+    #[wasm_bindgen(js_name = "fromSeed")]
+    pub fn from_seed(seed: u64) -> WasmRng {
+        WasmRng {
+            inner: SmallRng::seed_from_u64(seed),
+        }
+    }
+
+    /// Generates a random 32-bit unsigned integer.
+    #[wasm_bindgen(js_name = "nextU32")]
+    pub fn next_u32(&mut self) -> u32 {
+        self.inner.gen()
+    }
+
+    /// Generates a random 64-bit unsigned integer.
+    #[wasm_bindgen(js_name = "nextU64")]
+    pub fn next_u64(&mut self) -> u64 {
+        self.inner.gen()
+    }
+
+    /// Generates a random float between 0.0 and 1.0.
+    #[wasm_bindgen(js_name = "nextFloat")]
+    pub fn next_float(&mut self) -> f64 {
+        self.inner.gen()
+    }
+}
+
+impl Default for WasmRng {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WasmRng {
+    /// Returns a mutable reference to the inner RNG for use with Rust APIs.
+    pub fn as_rng(&mut self) -> &mut SmallRng {
+        &mut self.inner
+    }
+
+    /// Returns a mutable reference to the inner RNG.
+    /// Alias for `as_rng` to match the naming convention of other wrappers.
+    pub fn inner_mut(&mut self) -> &mut SmallRng {
+        &mut self.inner
+    }
+}

--- a/src/wasm/season.rs
+++ b/src/wasm/season.rs
@@ -1,0 +1,501 @@
+//! WASM bridge types for league season management.
+//!
+//! These types provide JavaScript/TypeScript-compatible wrappers around the
+//! core fbsim-core Rust types. They are intended exclusively for JS/TS
+//! consumers via WebAssembly and are not part of the public Rust API.
+//!
+//! Feature-gated behind the `wasm` Cargo feature. Compiled to WebAssembly
+//! via `wasm-pack`.
+
+use wasm_bindgen::prelude::*;
+
+use crate::league::season::{
+    LeagueSeason, LeagueSeasonPlayoffOptions, LeagueSeasonScheduleOptions,
+};
+use crate::wasm::conference::WasmLeagueConference;
+use crate::wasm::rng::WasmRng;
+use crate::wasm::team::WasmFootballTeam;
+
+/// A WASM-friendly wrapper around `LeagueSeason`.
+#[wasm_bindgen(js_name = "LeagueSeason")]
+pub struct WasmLeagueSeason {
+    inner: LeagueSeason,
+}
+
+#[wasm_bindgen(js_class = "LeagueSeason")]
+impl WasmLeagueSeason {
+    // ---------------------------------------------------------------
+    // Construction & Properties
+    // ---------------------------------------------------------------
+
+    /// Creates a new empty season (defaults to the current year).
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> WasmLeagueSeason {
+        WasmLeagueSeason {
+            inner: LeagueSeason::new(),
+        }
+    }
+
+    /// Gets the season year.
+    #[wasm_bindgen(getter)]
+    pub fn year(&self) -> usize {
+        *self.inner.year()
+    }
+
+    /// Sets the season year.
+    #[wasm_bindgen(setter)]
+    pub fn set_year(&mut self, year: usize) {
+        *self.inner.year_mut() = year;
+    }
+
+    /// Returns true if the season has started (any game played).
+    #[wasm_bindgen(getter)]
+    pub fn started(&self) -> bool {
+        self.inner.started()
+    }
+
+    /// Returns true if the regular season is complete.
+    #[wasm_bindgen(getter, js_name = "regularSeasonComplete")]
+    pub fn regular_season_complete(&self) -> bool {
+        self.inner.regular_season_complete()
+    }
+
+    /// Returns true if the entire season (including playoffs) is complete.
+    #[wasm_bindgen(getter)]
+    pub fn complete(&self) -> bool {
+        self.inner.complete()
+    }
+
+    // ---------------------------------------------------------------
+    // Team Management
+    // ---------------------------------------------------------------
+
+    /// Adds a team to the season.
+    #[wasm_bindgen(js_name = "addTeam")]
+    pub fn add_team(&mut self, id: usize, team: &WasmFootballTeam) -> Result<(), JsError> {
+        self.inner
+            .add_team(id, team.inner().clone())
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Checks if a team exists in the season.
+    #[wasm_bindgen(js_name = "teamExists")]
+    pub fn team_exists(&self, id: usize) -> bool {
+        self.inner.team_exists(id)
+    }
+
+    /// Returns the teams as a JSON object (BTreeMap<usize, FootballTeam>).
+    #[wasm_bindgen(getter)]
+    pub fn teams(&self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(self.inner.teams())
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    // ---------------------------------------------------------------
+    // Conference Management
+    // ---------------------------------------------------------------
+
+    /// Adds a conference to the season (takes ownership).
+    #[wasm_bindgen(js_name = "addConference")]
+    pub fn add_conference(
+        &mut self,
+        conference: WasmLeagueConference,
+    ) -> Result<(), JsError> {
+        self.inner
+            .add_conference(conference.into_inner())
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Returns the conferences as a JSON array.
+    #[wasm_bindgen(getter)]
+    pub fn conferences(&self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(self.inner.conferences())
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    // ---------------------------------------------------------------
+    // Schedule Generation
+    // ---------------------------------------------------------------
+
+    /// Generates the regular season schedule.
+    ///
+    /// `options` is a plain JS object matching `LeagueSeasonScheduleOptions`
+    /// (e.g. `{ division_games: 2, permute: true }`).
+    #[wasm_bindgen(js_name = "generateSchedule")]
+    pub fn generate_schedule(
+        &mut self,
+        options: LeagueSeasonScheduleOptions,
+        rng: &mut WasmRng,
+    ) -> Result<(), JsError> {
+        self.inner
+            .generate_schedule(options, rng.inner_mut())
+            .map_err(|e| JsError::new(&e))
+    }
+
+    // ---------------------------------------------------------------
+    // Regular Season Simulation
+    // ---------------------------------------------------------------
+
+    /// Simulates the entire season (regular season + playoffs if generated).
+    #[wasm_bindgen(js_name = "sim")]
+    pub fn sim(&mut self, rng: &mut WasmRng) -> Result<(), JsError> {
+        self.inner
+            .sim(rng.inner_mut())
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Simulates all remaining regular season weeks.
+    #[wasm_bindgen(js_name = "simRegularSeason")]
+    pub fn sim_regular_season(&mut self, rng: &mut WasmRng) -> Result<(), JsError> {
+        self.inner
+            .sim_regular_season(rng.inner_mut())
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Simulates all matchups in a single week.
+    #[wasm_bindgen(js_name = "simWeek")]
+    pub fn sim_week(&mut self, week: usize, rng: &mut WasmRng) -> Result<(), JsError> {
+        self.inner
+            .sim_week(week, rng.inner_mut())
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Simulates a single matchup to completion. Returns the game log as JSON.
+    #[wasm_bindgen(js_name = "simMatchup")]
+    pub fn sim_matchup(
+        &mut self,
+        week: usize,
+        matchup: usize,
+        rng: &mut WasmRng,
+    ) -> Result<JsValue, JsError> {
+        let game = self
+            .inner
+            .sim_matchup(week, matchup, rng.inner_mut())
+            .map_err(|e| JsError::new(&e))?;
+        serde_wasm_bindgen::to_value(&game).map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Simulates a single play of a matchup. Returns the game log as JSON
+    /// if the game finished on this play, or `undefined` if still in progress.
+    #[wasm_bindgen(js_name = "simPlay")]
+    pub fn sim_play(
+        &mut self,
+        week: usize,
+        matchup: usize,
+        rng: &mut WasmRng,
+    ) -> Result<JsValue, JsError> {
+        let result = self
+            .inner
+            .sim_play(week, matchup, rng.inner_mut())
+            .map_err(|e| JsError::new(&e))?;
+        match result {
+            Some(game) => {
+                serde_wasm_bindgen::to_value(&game).map_err(|e| JsError::new(&e.to_string()))
+            }
+            None => Ok(JsValue::UNDEFINED),
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Playoff Generation & Simulation
+    // ---------------------------------------------------------------
+
+    /// Generates the playoff bracket.
+    ///
+    /// `options` is a plain JS object matching `LeagueSeasonPlayoffOptions`.
+    #[wasm_bindgen(js_name = "generatePlayoffs")]
+    pub fn generate_playoffs(
+        &mut self,
+        options: LeagueSeasonPlayoffOptions,
+        rng: &mut WasmRng,
+    ) -> Result<(), JsError> {
+        self.inner
+            .generate_playoffs(options, rng.inner_mut())
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Generates the next playoff round (used for multi-round brackets).
+    #[wasm_bindgen(js_name = "generateNextPlayoffRound")]
+    pub fn generate_next_playoff_round(&mut self, rng: &mut WasmRng) -> Result<(), JsError> {
+        self.inner
+            .generate_next_playoff_round(rng.inner_mut())
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Simulates all remaining playoffs.
+    #[wasm_bindgen(js_name = "simPlayoffs")]
+    pub fn sim_playoffs(&mut self, rng: &mut WasmRng) -> Result<(), JsError> {
+        self.inner
+            .sim_playoffs(rng.inner_mut())
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Simulates a full playoff round across all conference brackets.
+    #[wasm_bindgen(js_name = "simPlayoffRound")]
+    pub fn sim_playoff_round(
+        &mut self,
+        round: usize,
+        rng: &mut WasmRng,
+    ) -> Result<(), JsError> {
+        self.inner
+            .sim_playoff_round(round, rng.inner_mut())
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Simulates a full round in a single conference bracket.
+    #[wasm_bindgen(js_name = "simPlayoffConferenceRound")]
+    pub fn sim_playoff_conference_round(
+        &mut self,
+        conference: usize,
+        round: usize,
+        rng: &mut WasmRng,
+    ) -> Result<(), JsError> {
+        self.inner
+            .sim_playoff_conference_round(conference, round, rng.inner_mut())
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Simulates a single playoff matchup to completion. Returns game log as JSON.
+    #[wasm_bindgen(js_name = "simPlayoffMatchup")]
+    pub fn sim_playoff_matchup(
+        &mut self,
+        conference: usize,
+        round: usize,
+        matchup: usize,
+        rng: &mut WasmRng,
+    ) -> Result<JsValue, JsError> {
+        let game = self
+            .inner
+            .sim_playoff_matchup(conference, round, matchup, rng.inner_mut())
+            .map_err(|e| JsError::new(&e))?;
+        serde_wasm_bindgen::to_value(&game).map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Simulates a single play of a playoff matchup. Returns game log as JSON
+    /// if the game finished, or `undefined` if still in progress.
+    #[wasm_bindgen(js_name = "simPlayoffPlay")]
+    pub fn sim_playoff_play(
+        &mut self,
+        conference: usize,
+        round: usize,
+        matchup: usize,
+        rng: &mut WasmRng,
+    ) -> Result<JsValue, JsError> {
+        let result = self
+            .inner
+            .sim_playoff_play(conference, round, matchup, rng.inner_mut())
+            .map_err(|e| JsError::new(&e))?;
+        match result {
+            Some(game) => {
+                serde_wasm_bindgen::to_value(&game).map_err(|e| JsError::new(&e.to_string()))
+            }
+            None => Ok(JsValue::UNDEFINED),
+        }
+    }
+
+    /// Simulates a full round of the winners bracket.
+    #[wasm_bindgen(js_name = "simWinnersBracketRound")]
+    pub fn sim_winners_bracket_round(
+        &mut self,
+        round: usize,
+        rng: &mut WasmRng,
+    ) -> Result<(), JsError> {
+        self.inner
+            .sim_winners_bracket_round(round, rng.inner_mut())
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Simulates a single winners bracket matchup to completion. Returns game log as JSON.
+    #[wasm_bindgen(js_name = "simWinnersBracketMatchup")]
+    pub fn sim_winners_bracket_matchup(
+        &mut self,
+        round: usize,
+        matchup: usize,
+        rng: &mut WasmRng,
+    ) -> Result<JsValue, JsError> {
+        let game = self
+            .inner
+            .sim_winners_bracket_matchup(round, matchup, rng.inner_mut())
+            .map_err(|e| JsError::new(&e))?;
+        serde_wasm_bindgen::to_value(&game).map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Simulates a single play of a winners bracket matchup. Returns game log
+    /// as JSON if the game finished, or `undefined` if still in progress.
+    #[wasm_bindgen(js_name = "simWinnersBracketPlay")]
+    pub fn sim_winners_bracket_play(
+        &mut self,
+        round: usize,
+        matchup: usize,
+        rng: &mut WasmRng,
+    ) -> Result<JsValue, JsError> {
+        let result = self
+            .inner
+            .sim_winners_bracket_play(round, matchup, rng.inner_mut())
+            .map_err(|e| JsError::new(&e))?;
+        match result {
+            Some(game) => {
+                serde_wasm_bindgen::to_value(&game).map_err(|e| JsError::new(&e.to_string()))
+            }
+            None => Ok(JsValue::UNDEFINED),
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Query Methods
+    // ---------------------------------------------------------------
+
+    /// Returns the season weeks as a JSON array.
+    #[wasm_bindgen(getter)]
+    pub fn weeks(&self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(self.inner.weeks())
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Returns the playoffs as a JSON object.
+    #[wasm_bindgen(getter)]
+    pub fn playoffs(&self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(self.inner.playoffs())
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Returns the overall standings as a JSON array of [teamId, record] pairs.
+    #[wasm_bindgen(getter)]
+    pub fn standings(&self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(&self.inner.standings())
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Returns the standings for a specific division as a JSON array.
+    #[wasm_bindgen(js_name = "divisionStandings")]
+    pub fn division_standings(
+        &self,
+        conf_index: usize,
+        div_id: usize,
+    ) -> Result<JsValue, JsError> {
+        let standings = self
+            .inner
+            .division_standings(conf_index, div_id)
+            .map_err(|e| JsError::new(&e))?;
+        serde_wasm_bindgen::to_value(&standings).map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Returns the standings for a specific conference as a JSON array.
+    #[wasm_bindgen(js_name = "conferenceStandings")]
+    pub fn conference_standings(&self, conf_index: usize) -> Result<JsValue, JsError> {
+        let standings = self
+            .inner
+            .conference_standings(conf_index)
+            .map_err(|e| JsError::new(&e))?;
+        serde_wasm_bindgen::to_value(&standings).map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Returns a team's division record as a JSON object.
+    #[wasm_bindgen(js_name = "divisionRecord")]
+    pub fn division_record(&self, team_id: usize) -> Result<JsValue, JsError> {
+        let record = self
+            .inner
+            .division_record(team_id)
+            .map_err(|e| JsError::new(&e))?;
+        serde_wasm_bindgen::to_value(&record).map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Returns a team's conference record as a JSON object.
+    #[wasm_bindgen(js_name = "conferenceRecord")]
+    pub fn conference_record(&self, team_id: usize) -> Result<JsValue, JsError> {
+        let record = self
+            .inner
+            .conference_record(team_id)
+            .map_err(|e| JsError::new(&e))?;
+        serde_wasm_bindgen::to_value(&record).map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Returns all matchups involving a team as a JSON object.
+    #[wasm_bindgen(js_name = "teamMatchups")]
+    pub fn team_matchups(&self, id: usize) -> Result<JsValue, JsError> {
+        let matchups = self
+            .inner
+            .team_matchups(id)
+            .map_err(|e| JsError::new(&e))?;
+        serde_wasm_bindgen::to_value(&matchups).map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Returns true if a team participated in the playoffs.
+    #[wasm_bindgen(js_name = "teamInPlayoffs")]
+    pub fn team_in_playoffs(&self, team_id: usize) -> Result<bool, JsError> {
+        self.inner
+            .team_in_playoffs(team_id)
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Returns a team's playoff record as a JSON object.
+    #[wasm_bindgen(js_name = "playoffRecord")]
+    pub fn playoff_record(&self, team_id: usize) -> Result<JsValue, JsError> {
+        let record = self
+            .inner
+            .playoff_record(team_id)
+            .map_err(|e| JsError::new(&e))?;
+        serde_wasm_bindgen::to_value(&record).map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Returns the playoff picture as a JSON object.
+    #[wasm_bindgen(js_name = "playoffPicture")]
+    pub fn playoff_picture(&self, num_teams: usize) -> Result<JsValue, JsError> {
+        let picture = self
+            .inner
+            .playoff_picture(num_teams)
+            .map_err(|e| JsError::new(&e))?;
+        serde_wasm_bindgen::to_value(&picture).map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Returns true if a team made it to the championship.
+    #[wasm_bindgen(js_name = "teamInChampionship")]
+    pub fn team_in_championship(&self, team_id: usize) -> Result<bool, JsError> {
+        self.inner
+            .team_in_championship(team_id)
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Returns true if a team won the championship.
+    #[wasm_bindgen(js_name = "teamWonChampionship")]
+    pub fn team_won_championship(&self, team_id: usize) -> Result<bool, JsError> {
+        self.inner
+            .team_won_championship(team_id)
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Returns the season as a JSON-serializable object.
+    #[wasm_bindgen(js_name = "toJSON")]
+    pub fn to_json(&self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(&self.inner)
+            .map_err(|e| JsError::new(&e.to_string()))
+    }
+}
+
+impl Default for WasmLeagueSeason {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WasmLeagueSeason {
+    /// Returns a reference to the inner `LeagueSeason`.
+    pub fn inner(&self) -> &LeagueSeason {
+        &self.inner
+    }
+
+    /// Returns a mutable reference to the inner `LeagueSeason`.
+    pub fn inner_mut(&mut self) -> &mut LeagueSeason {
+        &mut self.inner
+    }
+
+    /// Consumes the wrapper, returning the inner `LeagueSeason`.
+    pub fn into_inner(self) -> LeagueSeason {
+        self.inner
+    }
+
+    /// Creates a wrapper from an existing `LeagueSeason`.
+    pub fn from_inner(inner: LeagueSeason) -> Self {
+        WasmLeagueSeason { inner }
+    }
+}

--- a/src/wasm/team.rs
+++ b/src/wasm/team.rs
@@ -1,0 +1,360 @@
+//! WASM bridge types for team management.
+//!
+//! These types provide JavaScript/TypeScript-compatible wrappers around the
+//! core fbsim-core Rust types. They are intended exclusively for JS/TS
+//! consumers via WebAssembly and are not part of the public Rust API.
+//!
+//! Feature-gated behind the `wasm` Cargo feature. Compiled to WebAssembly
+//! via `wasm-pack`.
+
+use wasm_bindgen::prelude::*;
+
+use crate::team::coach::FootballTeamCoach;
+use crate::team::defense::FootballTeamDefense;
+use crate::team::offense::FootballTeamOffense;
+use crate::team::FootballTeam;
+
+/// A WASM-friendly wrapper around `FootballTeam`.
+///
+/// This wrapper provides JavaScript-accessible constructors and methods
+/// for creating and manipulating football teams.
+#[wasm_bindgen(js_name = "FootballTeam")]
+pub struct WasmFootballTeam {
+    inner: FootballTeam,
+}
+
+#[wasm_bindgen(js_class = "FootballTeam")]
+impl WasmFootballTeam {
+    /// Creates a new team with default values.
+    ///
+    /// The team will have the name "Null Island Defaults" and all
+    /// attributes set to 50.
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> WasmFootballTeam {
+        WasmFootballTeam {
+            inner: FootballTeam::new(),
+        }
+    }
+
+    /// Creates a new team with the specified overall ratings.
+    ///
+    /// # Arguments
+    /// * `name` - The team's full name (max 64 characters)
+    /// * `short_name` - The team's abbreviation (max 4 characters)
+    /// * `offense_overall` - Overall offensive rating (0-100)
+    /// * `defense_overall` - Overall defensive rating (0-100)
+    ///
+    /// # Errors
+    /// Returns an error if any rating is out of range or names are too long.
+    #[wasm_bindgen(js_name = "fromOveralls")]
+    pub fn from_overalls(
+        name: &str,
+        short_name: &str,
+        offense_overall: u32,
+        defense_overall: u32,
+    ) -> Result<WasmFootballTeam, JsError> {
+        FootballTeam::from_overalls(name, short_name, offense_overall, defense_overall)
+            .map(|inner| WasmFootballTeam { inner })
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Gets the team's name.
+    #[wasm_bindgen(getter)]
+    pub fn name(&self) -> String {
+        self.inner.name().to_string()
+    }
+
+    /// Gets the team's short name / abbreviation.
+    #[wasm_bindgen(getter, js_name = "shortName")]
+    pub fn short_name(&self) -> String {
+        self.inner.short_name().to_string()
+    }
+
+    /// Gets the team's offensive overall rating.
+    #[wasm_bindgen(getter, js_name = "offenseOverall")]
+    pub fn offense_overall(&self) -> u32 {
+        use crate::game::score::ScoreSimulatable;
+        self.inner.offense_overall()
+    }
+
+    /// Gets the team's defensive overall rating.
+    #[wasm_bindgen(getter, js_name = "defenseOverall")]
+    pub fn defense_overall(&self) -> u32 {
+        use crate::game::score::ScoreSimulatable;
+        self.inner.defense_overall()
+    }
+
+    /// Returns the team as a JSON-serializable object.
+    ///
+    /// This allows full access to all team properties from JavaScript.
+    #[wasm_bindgen(js_name = "toJSON")]
+    pub fn to_json(&self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(&self.inner).map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Creates a team from a JSON object.
+    ///
+    /// # Arguments
+    /// * `value` - A JavaScript object with team properties
+    ///
+    /// # Errors
+    /// Returns an error if the object is invalid or has out-of-range values.
+    #[wasm_bindgen(js_name = "fromJSON")]
+    pub fn from_json(value: JsValue) -> Result<WasmFootballTeam, JsError> {
+        let inner: FootballTeam =
+            serde_wasm_bindgen::from_value(value).map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(WasmFootballTeam { inner })
+    }
+}
+
+impl Default for WasmFootballTeam {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WasmFootballTeam {
+    /// Returns a reference to the inner `FootballTeam`.
+    ///
+    /// This is used internally for simulation functions.
+    pub fn inner(&self) -> &FootballTeam {
+        &self.inner
+    }
+
+    /// Creates a wrapper from an existing `FootballTeam`.
+    pub fn from_inner(inner: FootballTeam) -> Self {
+        WasmFootballTeam { inner }
+    }
+}
+
+/// A WASM-friendly wrapper around `FootballTeamCoach`.
+#[wasm_bindgen(js_name = "FootballTeamCoach")]
+pub struct WasmFootballTeamCoach {
+    inner: FootballTeamCoach,
+}
+
+#[wasm_bindgen(js_class = "FootballTeamCoach")]
+impl WasmFootballTeamCoach {
+    /// Creates a new coach with default values (all attributes at 50).
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> WasmFootballTeamCoach {
+        WasmFootballTeamCoach {
+            inner: FootballTeamCoach::new(),
+        }
+    }
+
+    /// Gets the coach's risk-taking tendency (0-100).
+    /// Higher values mean the coach is more likely to go for it on 4th down, etc.
+    #[wasm_bindgen(getter, js_name = "riskTaking")]
+    pub fn risk_taking(&self) -> u32 {
+        self.inner.risk_taking()
+    }
+
+    /// Gets the coach's run-pass tendency (0-100).
+    /// Lower values favor running, higher values favor passing.
+    #[wasm_bindgen(getter, js_name = "runPass")]
+    pub fn run_pass(&self) -> u32 {
+        self.inner.run_pass()
+    }
+
+    /// Gets the coach's up-tempo tendency (0-100).
+    /// Higher values mean faster play calling.
+    #[wasm_bindgen(getter, js_name = "upTempo")]
+    pub fn up_tempo(&self) -> u32 {
+        self.inner.up_tempo()
+    }
+
+    /// Returns the coach as a JSON-serializable object.
+    #[wasm_bindgen(js_name = "toJSON")]
+    pub fn to_json(&self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(&self.inner).map_err(|e| JsError::new(&e.to_string()))
+    }
+}
+
+impl Default for WasmFootballTeamCoach {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A WASM-friendly wrapper around `FootballTeamOffense`.
+#[wasm_bindgen(js_name = "FootballTeamOffense")]
+pub struct WasmFootballTeamOffense {
+    inner: FootballTeamOffense,
+}
+
+#[wasm_bindgen(js_class = "FootballTeamOffense")]
+impl WasmFootballTeamOffense {
+    /// Creates a new offense with default values (all attributes at 50).
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> WasmFootballTeamOffense {
+        WasmFootballTeamOffense {
+            inner: FootballTeamOffense::new(),
+        }
+    }
+
+    /// Creates an offense with all attributes set to the given overall rating.
+    #[wasm_bindgen(js_name = "fromOverall")]
+    pub fn from_overall(overall: u32) -> Result<WasmFootballTeamOffense, JsError> {
+        FootballTeamOffense::from_overall(overall)
+            .map(|inner| WasmFootballTeamOffense { inner })
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Gets the overall offensive rating.
+    #[wasm_bindgen(getter)]
+    pub fn overall(&self) -> u32 {
+        self.inner.overall()
+    }
+
+    /// Gets the passing rating.
+    #[wasm_bindgen(getter)]
+    pub fn passing(&self) -> u32 {
+        self.inner.passing()
+    }
+
+    /// Gets the rushing rating.
+    #[wasm_bindgen(getter)]
+    pub fn rushing(&self) -> u32 {
+        self.inner.rushing()
+    }
+
+    /// Gets the receiving rating.
+    #[wasm_bindgen(getter)]
+    pub fn receiving(&self) -> u32 {
+        self.inner.receiving()
+    }
+
+    /// Gets the blocking rating.
+    #[wasm_bindgen(getter)]
+    pub fn blocking(&self) -> u32 {
+        self.inner.blocking()
+    }
+
+    /// Gets the scrambling rating.
+    #[wasm_bindgen(getter)]
+    pub fn scrambling(&self) -> u32 {
+        self.inner.scrambling()
+    }
+
+    /// Gets the turnovers rating (higher = fewer turnovers).
+    #[wasm_bindgen(getter)]
+    pub fn turnovers(&self) -> u32 {
+        self.inner.turnovers()
+    }
+
+    /// Gets the field goals rating.
+    #[wasm_bindgen(getter, js_name = "fieldGoals")]
+    pub fn field_goals(&self) -> u32 {
+        self.inner.field_goals()
+    }
+
+    /// Gets the punting rating.
+    #[wasm_bindgen(getter)]
+    pub fn punting(&self) -> u32 {
+        self.inner.punting()
+    }
+
+    /// Gets the kickoffs rating.
+    #[wasm_bindgen(getter)]
+    pub fn kickoffs(&self) -> u32 {
+        self.inner.kickoffs()
+    }
+
+    /// Gets the kick return defense rating.
+    #[wasm_bindgen(getter, js_name = "kickReturnDefense")]
+    pub fn kick_return_defense(&self) -> u32 {
+        self.inner.kick_return_defense()
+    }
+
+    /// Returns the offense as a JSON-serializable object.
+    #[wasm_bindgen(js_name = "toJSON")]
+    pub fn to_json(&self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(&self.inner).map_err(|e| JsError::new(&e.to_string()))
+    }
+}
+
+impl Default for WasmFootballTeamOffense {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A WASM-friendly wrapper around `FootballTeamDefense`.
+#[wasm_bindgen(js_name = "FootballTeamDefense")]
+pub struct WasmFootballTeamDefense {
+    inner: FootballTeamDefense,
+}
+
+#[wasm_bindgen(js_class = "FootballTeamDefense")]
+impl WasmFootballTeamDefense {
+    /// Creates a new defense with default values (all attributes at 50).
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> WasmFootballTeamDefense {
+        WasmFootballTeamDefense {
+            inner: FootballTeamDefense::new(),
+        }
+    }
+
+    /// Creates a defense with all attributes set to the given overall rating.
+    #[wasm_bindgen(js_name = "fromOverall")]
+    pub fn from_overall(overall: u32) -> Result<WasmFootballTeamDefense, JsError> {
+        FootballTeamDefense::from_overall(overall)
+            .map(|inner| WasmFootballTeamDefense { inner })
+            .map_err(|e| JsError::new(&e))
+    }
+
+    /// Gets the overall defensive rating.
+    #[wasm_bindgen(getter)]
+    pub fn overall(&self) -> u32 {
+        self.inner.overall()
+    }
+
+    /// Gets the blitzing rating.
+    #[wasm_bindgen(getter)]
+    pub fn blitzing(&self) -> u32 {
+        self.inner.blitzing()
+    }
+
+    /// Gets the rush defense rating.
+    #[wasm_bindgen(getter, js_name = "rushDefense")]
+    pub fn rush_defense(&self) -> u32 {
+        self.inner.rush_defense()
+    }
+
+    /// Gets the pass defense rating.
+    #[wasm_bindgen(getter, js_name = "passDefense")]
+    pub fn pass_defense(&self) -> u32 {
+        self.inner.pass_defense()
+    }
+
+    /// Gets the coverage rating.
+    #[wasm_bindgen(getter)]
+    pub fn coverage(&self) -> u32 {
+        self.inner.coverage()
+    }
+
+    /// Gets the turnovers rating (higher = more turnovers forced).
+    #[wasm_bindgen(getter)]
+    pub fn turnovers(&self) -> u32 {
+        self.inner.turnovers()
+    }
+
+    /// Gets the kick returning rating.
+    #[wasm_bindgen(getter, js_name = "kickReturning")]
+    pub fn kick_returning(&self) -> u32 {
+        self.inner.kick_returning()
+    }
+
+    /// Returns the defense as a JSON-serializable object.
+    #[wasm_bindgen(js_name = "toJSON")]
+    pub fn to_json(&self) -> Result<JsValue, JsError> {
+        serde_wasm_bindgen::to_value(&self.inner).map_err(|e| JsError::new(&e.to_string()))
+    }
+}
+
+impl Default for WasmFootballTeamDefense {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["./pkg/web/fbsim_core.d.ts"],
+  "out": "docs-js",
+  "name": "fbsim-core JavaScript & TypeScript API",
+  "excludePrivate": true,
+  "includeVersion": true,
+  "compilerOptions": {
+    "lib": ["ES2015", "DOM"]
+  },
+  "highlightLanguages": ["typescript", "javascript", "rust", "bash", "sh"]
+}


### PR DESCRIPTION
Cherry-pick of PR:
- https://github.com/whatsacomputertho/fbsim-core/pull/91

For reference, see:
- https://github.com/whatsacomputertho/fbsim-core/issues/62

Includes commits:
* feat(wasm): add wasm module build & publish
* fix(ci): install wasm-pack before building
* feat(league): extend wasm coverage to league types
* sec(bytes): upgrade to secure bytes package
* doc(js): auto-doc generation for wasm library usage in js and ts
* sec(time): upgrade time crate to resolve CVE
