### PR TITLE
chore(release): prepare for v1.0.0-beta.2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fbsim-core"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 dependencies = [
  "bytes",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fbsim-core"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 authors = ["whatsacomputertho"]
 edition = "2021"
 description = "A library for american football simulation"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 > A library for american football simulation
 
-**Rust Docs**: https://docs.rs/fbsim-core/latest/fbsim_core/
+**Rust Docs**: [`fbsim-core` Rust crate documentation](https://docs.rs/fbsim-core/latest/fbsim_core/)
+
+**TypeDocs**: [`fbsim-core` TypeScript & JavaScript WASM module documentation](https://whatsacomputertho.github.io/fbsim-core/)
 
 **Contributing**: [CONTRIBUTING.md](https://github.com/whatsacomputertho/fbsim-core/blob/main/CONTRIBUTING.md)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whatsacomputertho/fbsim-core",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "A library for american football simulation",
   "main": "pkg/node/fbsim_core.js",
   "module": "pkg/web/fbsim_core.js",


### PR DESCRIPTION
In this PR, I update the root `README.md` as well as the `Cargo.toml`, and `package.json` package manifests to version as `v1.0.0-beta.2` and link to the appropriate documentation for the package.

For reference, see:
- https://github.com/whatsacomputertho/fbsim-core/issues/89