### PR TITLE
fix(release): setup node, publish npm package publicly

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
       - name: Install Dependencies
         run: |
           make build-dependencies

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ test:
 
 release:
 	cargo publish $(RELEASE_ARGS)
-	npm publish
+	npm publish --access public
 
 lint:
 	cargo clippy $(LINT_ARGS)


### PR DESCRIPTION
In this PR, I update the release workflow to properly setup an `.npmrc`, and I update the `Makefile` so that we set the `--access public` flag on the `npm publish` command.